### PR TITLE
Improve writeBinaryDatFormat:

### DIFF
--- a/spikeextractors/tools.py
+++ b/spikeextractors/tools.py
@@ -180,7 +180,7 @@ def saveProbeFile(recording, probe_file, format=None, radius=100, dimensions=Non
         raise NotImplementedError("Only .csv and .prb probe files can be saved.")
 
 
-def writeBinaryDatFormat(recording, save_path, transpose=False, dtype=None, chunksize=None):
+def writeBinaryDatFormat(recording, save_path, time_axis=0, dtype=None, chunksize=None):
     '''Saves the traces of a recording extractor in binary .dat format.
 
     Parameters
@@ -189,8 +189,9 @@ def writeBinaryDatFormat(recording, save_path, transpose=False, dtype=None, chun
         The recording extractor object to be saved in .dat format
     save_path: str
         The path to the file.
-    transpose: bool
-        If True the data are transpose (spyking_circus). Default is False (klusta, kilosort, yass)
+    time_axis: 0 (default) or 1
+        If 0 then traces are transposed to ensure (nb_sample, nb_channel) in the file.
+        If 1, the traces shape (nb_channel, nb_sample) is kept in the file.
     dtype: dtype
         Type of the saved data. Default float32
     chunksize: None or int
@@ -208,11 +209,12 @@ def writeBinaryDatFormat(recording, save_path, transpose=False, dtype=None, chun
         traces = recording.getTraces()
         if dtype is not None:
             traces = traces.astype(dtype)
-        if transpose:
+        if time_axis == 0:
             traces = traces.T
         with save_path.open('wb') as f:
             traces.tofile(f)
     else:
+        assert time_axis ==0, 'chunked writting work only with time_axis 0'
         n_sample = recording.getNumFrames()
         n_chan = recording.getNumChannels()
         n_chunk = n_sample // chunksize
@@ -224,7 +226,7 @@ def writeBinaryDatFormat(recording, save_path, transpose=False, dtype=None, chun
                                             end_frame=min((i+1)*chunksize, n_sample))
                 if dtype is not None:
                     traces = traces.astype(dtype)
-                if transpose:
+                if time_axis == 0:
                     traces = traces.T
                 f.write(traces.tobytes())
     

--- a/spikeextractors/tools.py
+++ b/spikeextractors/tools.py
@@ -200,7 +200,8 @@ def writeBinaryDatFormat(recording, save_path, transpose=False, dtype=None, chun
     -------
     '''
     save_path = Path(save_path)
-    if not save_path.suffix == '.dat':
+    if save_path.suffix == '':
+        # when suffix is already raw/bin/dat do not change it.
         save_path = save_path.parent / (save_path.name + '.dat')
     
     if chunksize is None:
@@ -217,10 +218,10 @@ def writeBinaryDatFormat(recording, save_path, transpose=False, dtype=None, chun
         n_chunk = n_sample // chunksize
         if n_sample % chunksize > 0:
             n_chunk += 1
-        with raw_filename.open('wb') as f:
+        with save_path.open('wb') as f:
             for i in range(n_chunk):
                 traces = recording.getTraces(start_frame=i*chunksize,
-                                                            end_frame=min((i+1)*chunksize, n_sample))
+                                            end_frame=min((i+1)*chunksize, n_sample))
                 if dtype is not None:
                     traces = traces.astype(dtype)
                 if transpose:


### PR DESCRIPTION
  * dtype=None by default
  * chunksize copy when chunksize is not None

This is about theses problems:
#103 #104 
https://github.com/SpikeInterface/spiketoolkit/issues/72