### PR TITLE
Changed the type information to be more informative. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/SpikeInterface/spikeextractors.svg?branch=master)](https://travis-ci.org/colehurwitz31/spikeextractors)
 
 Alpha Development
-Version 0.4.0
+Version 0.4.1
 
 
 # spikeextractors
@@ -118,7 +118,7 @@ labels=np.random.randint(1,num_units+1,size=num_events)
 SX=si.NumpySortingExtractor()
 for k in range(1,num_units+1):
     times_k=times[np.where(labels==k)[0]]
-    SX.addUnit(unit_id=k,times=times_k)
+    SX.add_unit(unit_id=k,times=times_k)
 ```
 <br/>
 

--- a/examples/getting_started_with_curation.ipynb
+++ b/examples/getting_started_with_curation.ipynb
@@ -50,7 +50,7 @@
     "SX=se.NumpySortingExtractor()\n",
     "for k in range(1,num_units+1):\n",
     "    times_k=times[np.where(labels==k)[0]]\n",
-    "    SX.addUnit(unit_id=k,times=times_k)\n",
+    "    SX.add_unit(unit_id=k,times=times_k)\n",
     "    \n",
     "#Add some features to the sorting extractor. These will be merged and split appropriately during curation\n",
     "spikes = 0\n",

--- a/examples/getting_started_with_sorting_extractors.ipynb
+++ b/examples/getting_started_with_sorting_extractors.ipynb
@@ -48,7 +48,7 @@
     "SX=se.NumpySortingExtractor()\n",
     "for k in range(1,num_units+1):\n",
     "    times_k=times[np.where(labels==k)[0]]\n",
-    "    SX.addUnit(unit_id=k,times=times_k)"
+    "    SX.add_unit(unit_id=k,times=times_k)"
    ]
   },
   {

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ pkg_name="spikeextractors"
 
 setuptools.setup(
     name=pkg_name,
-    version="0.4.0",
+    version="0.4.1",
     author="Cole Hurwitz, Jeremy Magland, Alessio Paolo Buccino, Matthias Hennig",
     author_email="colehurwitz@gmail.com",
     description="Python module for extracting recorded and spike sorted extracellular data from different file types and formats",

--- a/spikeextractors/RecordingExtractor.py
+++ b/spikeextractors/RecordingExtractor.py
@@ -13,7 +13,7 @@ class RecordingExtractor(ABC):
 
     extractor_name = ''
     installed = False  # check at class level if installed or not
-    _gui_params = {}
+    _gui_params = []
     installation_mesg = ""  # error message when not installed
 
     def __init__(self):

--- a/spikeextractors/SortingExtractor.py
+++ b/spikeextractors/SortingExtractor.py
@@ -12,7 +12,7 @@ class SortingExtractor(ABC):
     '''
     extractor_name = ''
     installed = False  # check at class level if installed or not
-    _gui_params = {}
+    _gui_params = []
     installation_mesg = ""  # error message when not installed
 
     def __init__(self):

--- a/spikeextractors/example_datasets/toy_example.py
+++ b/spikeextractors/example_datasets/toy_example.py
@@ -13,7 +13,7 @@ def toy_example(duration=10, num_channels=4, samplerate=30000, K=10):
     times, labels = synthesize_random_firings(K=K, duration=duration, samplerate=samplerate)
     labels = labels.astype(np.int64)
     SX = se.NumpySortingExtractor()
-    SX.setTimesLabels(times, labels)
+    SX.set_times_labels(times, labels)
     X = synthesize_timeseries(sorting=SX, waveforms=waveforms, noise_level=10, samplerate=samplerate, duration=duration,
                               waveform_upsamplefac=upsamplefac)
 

--- a/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
+++ b/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
@@ -9,13 +9,13 @@ class BinDatRecordingExtractor(RecordingExtractor):
     extractor_name = 'BinDatRecordingExtractor'
     installed = True  # check at class level if installed or not
     _gui_params = [
-        {'name': 'datfile', 'type': 'str', 'title': "str, Path to file"},
+        {'name': 'datfile', 'type': 'str', 'title': "Path to file"},
         {'name': 'samplerate', 'type': 'float', 'title': "Sampling rate in HZ"},
         {'name': 'numchan', 'type': 'int', 'title': "Number of channels"},
-        {'name': 'dtype', 'type': 'str', 'title': "np.dtype, The dtype of underlying data"},
-        {'name': 'recording_channels', 'type': 'str', 'value':None, 'default':None, 'title': "list, of recording channels"},
+        {'name': 'dtype', 'type': 'np.dtype', 'title': "The dtype of underlying data"},
+        {'name': 'recording_channels', 'type': 'list', 'value':None, 'default':None, 'title': "List of recording channels"},
         {'name': 'frames_first', 'type': 'bool', 'value':True, 'default':True, 'title': "Frames first"},
-        {'name': 'geom', 'type': 'str', 'value':None, 'default':None, 'title': "np.ndarray, 2D Numpy array of channel geometry"},
+        {'name': 'geom', 'type': 'np.ndarray', 'value':None, 'default':None, 'title': "2D Numpy array of channel geometry"},
         {'name': 'offset', 'type': 'int', 'value':0, 'default':0, 'title': "Offset in binary file"},
     ]
     installation_mesg = ""  # error message when not installed

--- a/spikeextractors/extractors/biocamrecordingextractor/biocamrecordingextractor.py
+++ b/spikeextractors/extractors/biocamrecordingextractor/biocamrecordingextractor.py
@@ -15,7 +15,7 @@ class BiocamRecordingExtractor(RecordingExtractor):
     extractor_name = 'BiocamRecordingExtractor'
     installed = HAVE_BIOCAM  # check at class level if installed or not
     _gui_params = [
-        {'name': 'recording_file', 'type': 'str', 'title': "str, Path to file"},
+        {'name': 'recording_file', 'type': 'str', 'title': "Path to file"},
         {'name': 'verbose', 'type': 'bool', 'value':False, 'default':False, 'title': "Verbose option"},
     ]
     installation_mesg = "To use the BiocamRecordingExtractor install h5py: \n\n pip install h5py\n\n"  # error message when not installed

--- a/spikeextractors/extractors/exdirextractors/exdirextractors.py
+++ b/spikeextractors/extractors/exdirextractors/exdirextractors.py
@@ -13,7 +13,7 @@ class ExdirRecordingExtractor(RecordingExtractor):
     extractor_name = 'ExdirRecordingExtractor'
     installed = HAVE_EXDIR  # check at class level if installed or not
     _gui_params = [
-        {'name': 'exdir_file', 'type': 'str', 'title': "str, Path to file"},
+        {'name': 'exdir_file', 'type': 'str', 'title': "Path to file"},
     ]
     installation_mesg = "To use the ExdirExtractors run:\n\n pip install exdir\n\n"  # error message when not installed
 

--- a/spikeextractors/extractors/hs2sortingextractor/hs2sortingextractor.py
+++ b/spikeextractors/extractors/hs2sortingextractor/hs2sortingextractor.py
@@ -12,7 +12,7 @@ class HS2SortingExtractor(SortingExtractor):
     extractor_name = 'HS2SortingExtractor'
     installed = HAVE_HS2SX  # check at class level if installed or not
     _gui_params = [
-        {'name': 'recording_file', 'type': 'str', 'title': "str, Path to file"},
+        {'name': 'recording_file', 'type': 'str', 'title': "Path to file"},
     ]
     installation_mesg = "To use the HS2SortingExtractor install h5py: \n\n pip install h5py\n\n"  # error message when not installed
 

--- a/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
+++ b/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
@@ -13,7 +13,7 @@ class IntanRecordingExtractor(RecordingExtractor):
     extractor_name = 'IntanRecordingExtractor'
     installed = HAVE_INTAN  # check at class level if installed or not
     _gui_params = [
-        {'name': 'recording_file', 'type': 'str', 'title': "str, Path to file"},
+        {'name': 'recording_file', 'type': 'str', 'title': "Path to file"},
         {'name': 'experiment_id', 'type': 'int', 'value':0, 'default':0, 'title': "Experiment ID"},
         {'name': 'recording_id', 'type': 'int', 'value':0, 'default':0, 'title': "Recording ID"},
     ]

--- a/spikeextractors/extractors/klustasortingextractor/klustasortingextractor.py
+++ b/spikeextractors/extractors/klustasortingextractor/klustasortingextractor.py
@@ -15,7 +15,7 @@ class KlustaSortingExtractor(SortingExtractor):
     extractor_name = 'KlustaSortingExtractor'
     installed = HAVE_KLSX  # check at class level if installed or not
     _gui_params = [
-        {'name': 'kwikfile', 'type': 'str', 'title': "str, Path to file"},
+        {'name': 'kwikfile', 'type': 'str', 'title': "Path to file"},
     ]
     installation_mesg = "To use the KlustaSortingExtractor install h5py: \n\n pip install h5py\n\n"  # error message when not installed
 

--- a/spikeextractors/extractors/mdaextractors/mdaextractors.py
+++ b/spikeextractors/extractors/mdaextractors/mdaextractors.py
@@ -11,7 +11,7 @@ class MdaRecordingExtractor(RecordingExtractor):
     extractor_name = 'MdaRecordingExtractor'
     installed = True  # check at class level if installed or not
     _gui_params = [
-        {'name': 'dataset_directory', 'type': 'str', 'title': "str, Path to folder"},
+        {'name': 'dataset_directory', 'type': 'str', 'title': "Path to folder"},
         {'name': 'download', 'type': 'bool', 'value':True, 'default':True, 'title': "Download the folder if online"},
     ]
     installation_mesg = ""  # error message when not installed

--- a/spikeextractors/extractors/mearecextractors/mearecextractors.py
+++ b/spikeextractors/extractors/mearecextractors/mearecextractors.py
@@ -17,7 +17,7 @@ class MEArecRecordingExtractor(RecordingExtractor):
     extractor_name = 'MEArecRecordingExtractor'
     installed = HAVE_MREX  # check at class level if installed or not
     _gui_params = [
-        {'name': 'recording_path', 'type': 'str', 'title': "str, Path to file"},
+        {'name': 'recording_path', 'type': 'str', 'title': "Path to file"},
     ]
     installation_mesg = "To use the MEArec extractors, install MEArec: \n\n pip install MEArec\n\n"  # error message when not installed
 

--- a/spikeextractors/extractors/numpyextractors/numpyextractors.py
+++ b/spikeextractors/extractors/numpyextractors/numpyextractors.py
@@ -52,18 +52,18 @@ class NumpySortingExtractor(SortingExtractor):
         self._units = {}
         # self._properties = {}
 
-    def loadFromExtractor(self, sorting):
+    def load_from_extractor(self, sorting):
         ids = sorting.get_unit_ids()
         for id in ids:
-            self.addUnit(id, sorting.get_unit_spike_train(id))
+            self.add_unit(id, sorting.get_unit_spike_train(id))
 
-    def setTimesLabels(self, times, labels):
+    def set_times_labels(self, times, labels):
         units = np.sort(np.unique(labels))
         for unit in units:
             times0 = times[np.where(labels == unit)[0]]
-            self.addUnit(unit_id=int(unit), times=times0)
+            self.add_unit(unit_id=int(unit), times=times0)
 
-    def addUnit(self, unit_id, times):
+    def add_unit(self, unit_id, times):
         self._unit_ids.append(unit_id)
         self._units[unit_id] = dict(times=times)
 

--- a/spikeextractors/extractors/openephysextractors/openephysextractors.py
+++ b/spikeextractors/extractors/openephysextractors/openephysextractors.py
@@ -16,7 +16,7 @@ class OpenEphysRecordingExtractor(RecordingExtractor):
         {'name': 'recording_file', 'type': 'str', 'title': "str, Path to file"},
         {'name': 'experiment_id', 'type': 'int', 'value':0, 'default':0, 'title': "Experiment ID"},
         {'name': 'recording_id', 'type': 'int', 'value':0, 'default':0, 'title': "Recording ID"},
-        {'name': 'dtype', 'type': 'list',  'value':'float', 'default':'float', 'values':['float', 'int16']},
+        {'name': 'dtype', 'type': 'str',  'value':'float', 'default':'float', 'title':"dtype ('float' or 'int')"},
     ]
 
     installation_mesg = "To use the OpenEphys extractor, install pyopenephys: \n\n pip install pyopenephys\n\n"  # error message when not installed

--- a/spikeextractors/extractors/physortingextractor/physortingextractor.py
+++ b/spikeextractors/extractors/physortingextractor/physortingextractor.py
@@ -7,7 +7,7 @@ class PhySortingExtractor(SortingExtractor):
     extractor_name = 'PhySortingExtractor'
     installed = True  # check at class level if installed or not
     _gui_params = [
-        {'name': 'phy_folder', 'type': 'str', 'title': "str, Path to folder"},
+        {'name': 'phy_folder', 'type': 'str', 'title': "Path to folder"},
     ]
     installation_mesg = ""  # error message when not installed
 

--- a/spikeextractors/extractors/spykingcircussortingextractor/spykingcircussortingextractor.py
+++ b/spikeextractors/extractors/spykingcircussortingextractor/spykingcircussortingextractor.py
@@ -13,7 +13,7 @@ class SpykingCircusSortingExtractor(SortingExtractor):
     extractor_name = 'SpykingCircusSortingExtractor'
     installed = HAVE_SCSX  # check at class level if installed or not
     _gui_params = [
-        {'name': 'spykingcircus_folder', 'type': 'str', 'title': "str, Path to folder"},
+        {'name': 'spykingcircus_folder', 'type': 'str', 'title': "Path to folder"},
     ]
     installation_mesg = "To use the SpykingCircusSortingExtractor install h5py: \n\n pip install h5py\n\n"
                                # error message when not installed

--- a/spikeextractors/extractors/tridesclousextractor/tridesclousextractor.py
+++ b/spikeextractors/extractors/tridesclousextractor/tridesclousextractor.py
@@ -13,8 +13,8 @@ class TridesclousSortingExtractor(SortingExtractor):
     extractor_name = 'TridesclousSortingExtractor'
     installed = HAVE_TDC  # check at class level if installed or not
     _gui_params = [
-        {'name': 'tdc_folder', 'type': 'str', 'title': "str, Path to folder"},
-        {'name': 'chan_grp', 'type': 'str', 'value':None, 'default':None, 'title': "list, List of channel groups"},
+        {'name': 'tdc_folder', 'type': 'str', 'title': "Path to folder"},
+        {'name': 'chan_grp', 'type': 'list', 'value':None, 'default':None, 'title': "List of channel groups"},
     ]
     installation_mesg = "must install tridesclous" # error message when not installed
 

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -35,16 +35,16 @@ class TestExtractors(unittest.TestCase):
         SX = se.NumpySortingExtractor()
         spike_times = [200, 300, 400]
         train1 = np.sort(np.rint(np.random.uniform(0, num_frames, spike_times[0])).astype(int))
-        SX.addUnit(unit_id=1, times=train1)
-        SX.addUnit(unit_id=2, times=np.sort(np.random.uniform(0, num_frames, spike_times[1])))
-        SX.addUnit(unit_id=3, times=np.sort(np.random.uniform(0, num_frames, spike_times[2])))
+        SX.add_unit(unit_id=1, times=train1)
+        SX.add_unit(unit_id=2, times=np.sort(np.random.uniform(0, num_frames, spike_times[1])))
+        SX.add_unit(unit_id=3, times=np.sort(np.random.uniform(0, num_frames, spike_times[2])))
         SX.set_unit_property(unit_id=1, property_name='stablility', value=80)
         SX2 = se.NumpySortingExtractor()
         spike_times2 = [100, 150, 450]
         train2 = np.rint(np.random.uniform(0, num_frames, spike_times[0])).astype(int)
-        SX2.addUnit(unit_id=3, times=train2)
-        SX2.addUnit(unit_id=4, times=np.random.uniform(0, num_frames, spike_times2[1]))
-        SX2.addUnit(unit_id=5, times=np.random.uniform(0, num_frames, spike_times2[2]))
+        SX2.add_unit(unit_id=3, times=train2)
+        SX2.add_unit(unit_id=4, times=np.random.uniform(0, num_frames, spike_times2[1]))
+        SX2.add_unit(unit_id=5, times=np.random.uniform(0, num_frames, spike_times2[2]))
         SX2.set_unit_property(unit_id=4, property_name='stablility', value=80)
         RX.set_channel_property(channel_id=0, property_name='location', value=(0, 0))
         example_info = dict(

--- a/tests/test_numpy_extractors.py
+++ b/tests/test_numpy_extractors.py
@@ -26,9 +26,9 @@ class TestNumpyExtractors(unittest.TestCase):
         self.SX = se.NumpySortingExtractor()
         L = 200
         self._train1 = np.rint(np.random.uniform(0, N, L)).astype(int)
-        self.SX.addUnit(unit_id=1, times=self._train1)
-        self.SX.addUnit(unit_id=2, times=np.random.uniform(0, N, L))
-        self.SX.addUnit(unit_id=3, times=np.random.uniform(0, N, L))
+        self.SX.add_unit(unit_id=1, times=self._train1)
+        self.SX.add_unit(unit_id=2, times=np.random.uniform(0, N, L))
+        self.SX.add_unit(unit_id=3, times=np.random.uniform(0, N, L))
 
     def tearDown(self):
         pass


### PR DESCRIPTION
@samuelgarcia I am changing the type information in the params and moving away from PyQtGraph types which can only be 'str', 'bool', etc. 

The reasons are as follows:

1. There is an annoying bug for PyQtGraph default values (hasDefault always returns True)

2. I want to include more interesting types like 'list' and 'np.dtype' and 'RecordingExtractor' so I think it is best if we have our own parameter reader. It doesn't need to be as complex as PyQtGraph, but it should handle lists and other types more seamlessly.