### PR TITLE
Fixes to h5 order in MEArec and KlustaExtractor

### DIFF
--- a/spikeextractors/extractors/klustaextractors/klustaextractors.py
+++ b/spikeextractors/extractors/klustaextractors/klustaextractors.py
@@ -72,6 +72,10 @@ class KlustaSortingExtractor(SortingExtractor):
         channel_groups = F.get('channel_groups')
         self._spiketrains = []
         self._unit_ids = []
+        unique_units = []
+        klusta_units = []
+        groups = []
+        unit = 0
         for cgroup in channel_groups:
             group_id = int(cgroup)
             try:
@@ -84,8 +88,17 @@ class KlustaSortingExtractor(SortingExtractor):
                 idx = np.nonzero(clusters == int(cluster_id))
                 st = np.array(channel_groups[cgroup]['spikes']['time_samples'])[idx]
                 self._spiketrains.append(st)
-                self._unit_ids.append(int(cluster_id))
-                self.set_unit_property(int(cluster_id), 'group', group_id)
+                klusta_units.append(int(cluster_id))
+                unique_units.append(unit)
+                unit += 1
+                groups.append(group_id)
+        if len(np.unique(klusta_units)) == len(np.unique(unique_units)):
+            self._unit_ids = klusta_units
+        else:
+            print('Klusta units are not unique! Using unique unit ids')
+            self._unit_ids = unique_units
+        for i, u in enumerate(self._unit_ids):
+            self.set_unit_property(u, 'group', groups[i])
 
     def get_unit_ids(self):
         return list(self._unit_ids)

--- a/spikeextractors/extractors/mearecextractors/mearecextractors.py
+++ b/spikeextractors/extractors/mearecextractors/mearecextractors.py
@@ -77,11 +77,11 @@ class MEArecRecordingExtractor(RecordingExtractor):
             channel_ids = range(self.get_num_channels())
         if np.any(np.diff(channel_ids) < 0):
             sorted_idx = np.argsort(channel_ids)
-            print(np.sort(channel_ids))
             recordings = self._recordings[np.sort(channel_ids), start_frame:end_frame]
             return recordings[sorted_idx]
         else:
             return self._recordings[np.array(channel_ids), start_frame:end_frame]
+        
     @staticmethod
     def write_recording(recording, save_path):
         '''

--- a/spikeextractors/extractors/mearecextractors/mearecextractors.py
+++ b/spikeextractors/extractors/mearecextractors/mearecextractors.py
@@ -81,7 +81,7 @@ class MEArecRecordingExtractor(RecordingExtractor):
             return recordings[sorted_idx]
         else:
             return self._recordings[np.array(channel_ids), start_frame:end_frame]
-        
+
     @staticmethod
     def write_recording(recording, save_path):
         '''

--- a/spikeextractors/extractors/mearecextractors/mearecextractors.py
+++ b/spikeextractors/extractors/mearecextractors/mearecextractors.py
@@ -75,8 +75,13 @@ class MEArecRecordingExtractor(RecordingExtractor):
             end_frame = self.get_num_frames()
         if channel_ids is None:
             channel_ids = range(self.get_num_channels())
-        return self._recordings[channel_ids, start_frame:end_frame]
-
+        if np.any(np.diff(channel_ids) < 0):
+            sorted_idx = np.argsort(channel_ids)
+            print(np.sort(channel_ids))
+            recordings = self._recordings[np.sort(channel_ids), start_frame:end_frame]
+            return recordings[sorted_idx]
+        else:
+            return self._recordings[np.array(channel_ids), start_frame:end_frame]
     @staticmethod
     def write_recording(recording, save_path):
         '''


### PR DESCRIPTION
- if channel_ids is not ordered in MEArecRecordingExtractor it throws an Error. Patched it
- if running klusta without grouping property but the group information is available, klusta still runs split by group and the unit_ids must be reset to have unique ids