### PR TITLE
Fixed property handling in multisortingextractor

### DIFF
--- a/spikeextractors/MultiSortingExtractor.py
+++ b/spikeextractors/MultiSortingExtractor.py
@@ -73,6 +73,17 @@ class MultiSortingExtractor(SortingExtractor):
     def get_sampling_frequency(self):
         return self._SXs[0].get_sampling_frequency()
 
+
+    def set_unit_property(self, unit_id, property_name, value):
+        if self._allzeros:
+            if unit_id not in self._unit_map.keys():
+                raise ValueError("Non-valid unit_id")
+            sx = self._unit_map[unit_id]['sx']
+            unit_id_sx = self._unit_map[unit_id]['unit']
+            self._SXs[sx].set_unit_property(unit_id_sx, property_name, value)
+        else:
+            raise NotImplementedError()
+
     def get_unit_property(self, unit_id, property_name):
         if self._allzeros:
             if unit_id not in self._unit_map.keys():
@@ -82,7 +93,23 @@ class MultiSortingExtractor(SortingExtractor):
             return self._SXs[sx].get_unit_property(unit_id_sx, property_name)
         else:
             raise NotImplementedError()
-
+    
+    def get_unit_property_names(self, unit_id=None):
+        if not self._allzeros:
+            property_names = []
+        else:
+            if(unit_id is None):
+                property_names = []
+                for sx in self._SXs:
+                    property_names_sx = sx.get_unit_property_names(unit_id)
+                    for property_name in property_names_sx:
+                        property_names.append(property_name)
+                property_names = list(set(property_names))
+            else:
+                sx = self._unit_map[unit_id]['sx']
+                unit_id_sx = self._unit_map[unit_id]['unit']
+                property_names = self._SXs[sx].get_unit_property_names(unit_id_sx)
+        return property_names
 
     def get_unit_spike_features(self, unit_id, feature_name, start_frame=None, end_frame=None):
         if self._allzeros:
@@ -93,7 +120,6 @@ class MultiSortingExtractor(SortingExtractor):
             return self._SXs[sx].get_unit_spike_features(unit_id_sx, feature_name, start_frame=start_frame, end_frame=end_frame)
         else:
             raise NotImplementedError()
-
 
     def get_unit_spike_feature_names(self, unit_id=None):
         if self._allzeros:

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -179,39 +179,6 @@ class TestExtractors(unittest.TestCase):
         RX_sub = RX_multi.get_epoch('C')
         self._check_recordings_equal(self.RX, RX_sub)
 
-    # def test_curation_sorting_extractor(self):
-    #     #Dummy features for testing merging and splitting of features
-    #     self.SX.set_unit_spike_features(1, 'f_int', range(0 + 1, len(self.SX.get_unit_spike_train(1)) + 1))
-    #     self.SX.set_unit_spike_features(2, 'f_int', range(0, len(self.SX.get_unit_spike_train(2))))
-    #     self.SX.set_unit_spike_features(2, 'bad_features', np.repeat(1, len(self.SX.get_unit_spike_train(2))))
-    #     self.SX.set_unit_spike_features(3, 'f_int', range(0, len(self.SX.get_unit_spike_train(3))))
-    # 
-    #     CSX = se.CurationSortingExtractor(
-    #         parent_sorting=self.SX
-    #     )
-    #     CSX.merge_units(unit_ids=[1, 2])
-    #     original_spike_train = np.concatenate((self.SX.get_unit_spike_train(1), self.SX.get_unit_spike_train(2)))
-    #     indices_sort = np.argsort(original_spike_train)
-    #     original_spike_train = original_spike_train[indices_sort]
-    #     original_features = np.concatenate((self.SX.get_unit_spike_features(1, 'f_int'), self.SX.get_unit_spike_features(2, 'f_int')))
-    #     original_features = original_features[indices_sort]
-    #     self.assertTrue(np.array_equal(CSX.get_unit_spike_train(4), original_spike_train))
-    #     self.assertTrue(np.array_equal(CSX.get_unit_spike_features(4, 'f_int'), original_features))
-    #     self.assertTrue(np.array_equal(np.asarray(CSX.get_unit_spike_feature_names(4)), np.asarray(['f_int'])))
-    #     self.assertEqual(CSX.get_sampling_frequency(), self.SX.get_sampling_frequency())
-    # 
-    #     CSX.split_unit(unit_id=3, indices=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    #     original_spike_train = self.SX.get_unit_spike_train(3)
-    #     original_features = self.SX.get_unit_spike_features(3, 'f_int')
-    #     split_spike_train_1 = CSX.get_unit_spike_train(5)
-    #     split_spike_train_2 = CSX.get_unit_spike_train(6)
-    #     split_features_1 = CSX.get_unit_spike_features(5, 'f_int')
-    #     split_features_2 = CSX.get_unit_spike_features(6, 'f_int')
-    #     self.assertTrue(np.array_equal(original_spike_train[:10], split_spike_train_1))
-    #     self.assertTrue(np.array_equal(original_spike_train[10:], split_spike_train_2))
-    #     self.assertTrue(np.array_equal(original_features[:10], split_features_1))
-    #     self.assertTrue(np.array_equal(original_features[10:], split_features_2))
-
     def test_multi_sub_sorting_extractor(self):
         N = self.RX.get_num_frames()
         SX_multi = se.MultiSortingExtractor(
@@ -238,14 +205,16 @@ class TestExtractors(unittest.TestCase):
         )
         SX_sub = se.SubSortingExtractor(parent_sorting=SX_multi, start_frame=N, end_frame=2 * N)
         self._check_sortings_equal(self.SX, SX_sub)
-
+        
         N = self.RX.get_num_frames()
         SX_multi = se.MultiSortingExtractor(
             sortings=[self.SX, self.SX, self.SX],
             start_frames=[0, 0, 0]
         )
+        SX_multi.set_unit_property(unit_id=1, property_name='dummy', value=5)
         SX_sub = se.SubSortingExtractor(parent_sorting=SX_multi, start_frame=0)
         self._check_sortings_equal(SX_multi, SX_sub)
+        self.assertEqual(SX_multi.get_unit_property(1, 'dummy'), SX_sub.get_unit_property(1, 'dummy'))
 
         N = self.RX.get_num_frames()
         SX_multi = se.MultiSortingExtractor(


### PR DESCRIPTION
Adding new unit properties and getting unit property names were broken in the multisortingextractor (I had to override the original functions in the class). 