### PR TITLE
Updated mearec for h5 destructor

### DIFF
--- a/spikeextractors/extractors/mearecextractors/mearecextractors.py
+++ b/spikeextractors/extractors/mearecextractors/mearecextractors.py
@@ -38,16 +38,16 @@ class MEArecRecordingExtractor(RecordingExtractor):
 
     def _initialize(self):
         assert HAVE_MREX, "To use the MEArec extractors, install MEArec: \n\n pip install MEArec\n\n"
-        recgen = mr.load_recordings(recordings=self._recording_path, return_h5_objects=True, check_suffix=False)
-        self._fs = recgen.info['recordings']['fs']
-        self._recordings = recgen.recordings
+        self._recgen = mr.load_recordings(recordings=self._recording_path, return_h5_objects=True, check_suffix=False)
+        self._fs = self._recgen.info['recordings']['fs']
+        self._recordings = self._recgen.recordings
         self._num_channels, self._num_frames = self._recordings.shape
-        if len(np.array(recgen.channel_positions)) == self._num_channels:
-            self._locations = np.array(recgen.channel_positions)
+        if len(np.array(self._recgen.channel_positions)) == self._num_channels:
+            self._locations = np.array(self._recgen.channel_positions)
             if self._locs_2d:
-                if 'electrodes' in recgen.info.keys():
-                    if 'plane' in recgen.info['electrodes'].keys():
-                        probe_plane = recgen.info['electrodes']['plane']
+                if 'electrodes' in self._recgen.info.keys():
+                    if 'plane' in self._recgen.info['electrodes'].keys():
+                        probe_plane = self._recgen.info['electrodes']['plane']
                         if probe_plane == 'xy':
                             self._locations = self._locations[:, :2]
                         elif probe_plane == 'yz':
@@ -73,7 +73,7 @@ class MEArecRecordingExtractor(RecordingExtractor):
         if end_frame is None:
             end_frame = self.get_num_frames()
         if channel_ids is None:
-            channel_ids = range(self.get_num_channels())
+            channel_ids = list(range(self.get_num_channels()))
         if np.any(np.diff(channel_ids) < 0):
             sorted_idx = np.argsort(channel_ids)
             recordings = self._recordings[np.sort(channel_ids), start_frame:end_frame]

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -17,8 +17,8 @@ import spikeextractors as se
 class TestExtractors(unittest.TestCase):
     def setUp(self):
         self.RX, self.RX2, self.RX3, self.SX, self.SX2, self.example_info = self._create_example()
-        self.test_dir = tempfile.mkdtemp()
-        # self.test_dir = '.'
+        # self.test_dir = tempfile.mkdtemp()
+        self.test_dir = '.'
 
     def tearDown(self):
         # Remove the directory after the test
@@ -121,7 +121,7 @@ class TestExtractors(unittest.TestCase):
         path1 = self.test_dir + '/raw.h5'
         se.MEArecRecordingExtractor.write_recording(self.RX, path1)
         RX_mearec = se.MEArecRecordingExtractor(path1)
-        tr = RX_mearec.get_traces(channel_ids=[0,1], end_frame=1000)
+        tr = RX_mearec.get_traces(channel_ids=[0, 1], end_frame=1000)
         self._check_recording_return_types(RX_mearec)
         self._check_recordings_equal(self.RX, RX_mearec)
 

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -17,8 +17,8 @@ import spikeextractors as se
 class TestExtractors(unittest.TestCase):
     def setUp(self):
         self.RX, self.RX2, self.RX3, self.SX, self.SX2, self.example_info = self._create_example()
-        # self.test_dir = tempfile.mkdtemp()
-        self.test_dir = '.'
+        self.test_dir = tempfile.mkdtemp()
+        # self.test_dir = '.'
 
     def tearDown(self):
         # Remove the directory after the test


### PR DESCRIPTION
Update to new h5 backend.

The recgen object need to be a member variable otherwise the underlying h5 file gets closed by the destructor