### PR TITLE
added internal extraction tools

### DIFF
--- a/spikeextractors/__init__.py
+++ b/spikeextractors/__init__.py
@@ -9,7 +9,7 @@ from .multisortingextractor import concatenate_sortings, MultiSortingExtractor
 from .extractorlist import *
 
 from . import example_datasets
-from .extraction_tools import load_probe_file, save_probe_file, read_binary, write_binary_dat_format, \
+from .extraction_tools import load_probe_file, save_to_probe_file, read_binary, write_binary_dat_format, \
     get_sub_extractors_by_property
 
 from .version import version as __version__

--- a/spikeextractors/__init__.py
+++ b/spikeextractors/__init__.py
@@ -9,7 +9,7 @@ from .multisortingextractor import concatenate_sortings, MultiSortingExtractor
 from .extractorlist import *
 
 from . import example_datasets
-from .extraction_tools import load_probe_file, save_to_probe_file, read_binary, write_binary_dat_format, \
+from .extraction_tools import load_probe_file, save_to_probe_file, read_binary, write_to_binary_dat_format, \
     get_sub_extractors_by_property
 
 from .version import version as __version__

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -248,7 +248,7 @@ def read_binary(file, numchan, dtype, frames_first=True, offset=0):
     return samples
 
 
-def write_binary_dat_format(recording, save_path, time_axis=0, dtype=None, chunksize=None):
+def write_to_binary_dat_format(recording, save_path, time_axis=0, dtype=None, chunksize=None):
     '''Saves the traces of a recording extractor in binary .dat format.
 
     Parameters

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -1,8 +1,4 @@
 import numpy as np
-from .recordingextractor import RecordingExtractor
-from .sortingextractor import SortingExtractor
-from .subrecordingextractor import SubRecordingExtractor
-from .subsortingextractor import SubSortingExtractor
 import csv
 import os
 import sys
@@ -58,9 +54,10 @@ def write_python(path, dict):
 
 
 def load_probe_file(recording, probe_file, channel_map=None, channel_groups=None, verbose=False):
-    '''Loads channel information into recording extractor. If a .prb file is given,
-    then 'location' and 'group' information for each channel is stored. If a .csv
-    file is given, then it will only store 'location'
+    '''This function returns a SubRecordingExtractor that contains information from the given
+    probe file (channel locations, groups, etc.) If a .prb file is given, then 'location' and 'group' 
+    information for each channel is added to the SubRecordingExtractor. If a .csv file is given, then 
+    it will only add 'location' to the SubRecordingExtractor.
 
     Parameters
     ----------
@@ -73,8 +70,11 @@ def load_probe_file(recording, probe_file, channel_map=None, channel_groups=None
 
     Returns
     ---------
-    subRecordingExtractor
+    subrecording = SubRecordingExtractor
+        The extractor containing all of the probe information.
     '''
+    from .subrecordingextractor import SubRecordingExtractor
+    from .subsortingextractor import SubSortingExtractor
     probe_file = Path(probe_file)
     if probe_file.suffix == '.prb':
         probe_dict = read_python(probe_file)
@@ -171,9 +171,9 @@ def load_probe_file(recording, probe_file, channel_map=None, channel_groups=None
     return subrecording
 
 
-def save_probe_file(recording, probe_file, format=None, radius=100, dimensions=None, verbose=False):
+def save_to_probe_file(recording, probe_file, format=None, radius=100, dimensions=None, verbose=False):
     '''Saves probe file from the channel information of the given recording
-    extractor
+    extractor.
 
     Parameters
     ----------
@@ -234,9 +234,6 @@ def read_binary(file, numchan, dtype, frames_first=True, offset=0):
     offset: int
         number of offset bytes
 
-    Returns
-    -------
-
     '''
     numchan = int(numchan)
     with Path(file).open() as f:
@@ -267,9 +264,7 @@ def write_binary_dat_format(recording, save_path, time_axis=0, dtype=None, chunk
         Type of the saved data. Default float32
     chunksize: None or int
         If not None then the copy done by chunk size.
-        Thi avoid to much memory consumption for big files.
-    Returns
-    -------
+        This avoid to much memory consumption for big files.
     '''
     save_path = Path(save_path)
     if save_path.suffix == '':
@@ -304,12 +299,11 @@ def write_binary_dat_format(recording, save_path, time_axis=0, dtype=None, chunk
 
 
 def get_sub_extractors_by_property(extractor, property_name, return_property_list=False):
-    '''Divides Recording or Sorting Extractor based on the property_name (e.g. group)
+    '''Returns a list of SubRecordingExtractors from this RecordingExtractor based on the given
+    property_name (e.g. group)
 
     Parameters
     ----------
-    extractor: RecordingExtractor or SortingExtractor
-        The extractor to be subdivided in subextractors
     property_name: str
         The property used to subdivide the extractor
     return_property_list: bool
@@ -317,9 +311,16 @@ def get_sub_extractors_by_property(extractor, property_name, return_property_lis
 
     Returns
     -------
-    List of subextractors
-
+    sub_list: list
+        The list of subextractors to be returned.
+    OR
+    sub_list, prop_list
+        If return_property_list is True, the property list will be returned as well.
     '''
+    from .recordingextractor import RecordingExtractor
+    from .sortingextractor import SortingExtractor
+    from .subrecordingextractor import SubRecordingExtractor
+    from .subsortingextractor import SubSortingExtractor
     if isinstance(extractor, RecordingExtractor):
         if property_name not in extractor.get_shared_channel_property_names():
             raise ValueError("'property_name' must be must be a property of the recording channels")

--- a/spikeextractors/extractorlist.py
+++ b/spikeextractors/extractorlist.py
@@ -38,7 +38,6 @@ recording_extractor_full_list = [
 ]
 
 recording_extractor_dict = {recording_class.extractor_name: recording_class for recording_class in recording_extractor_full_list}
-
 installed_recording_extractor_list = [rx for rx in recording_extractor_full_list if rx.installed]
 
 sorting_extractor_full_list = [
@@ -56,5 +55,4 @@ sorting_extractor_full_list = [
 ]
 
 installed_sorting_extractor_list = [sx for sx in sorting_extractor_full_list if sx.installed]
-
 sorting_extractor_dict = {sorting_class.extractor_name: sorting_class for sorting_class in sorting_extractor_full_list}

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 import numpy as np
 import copy
-from .extraction_tools import load_probe_file, save_to_probe_file, write_binary_dat_format, get_sub_extractors_by_property
+from .extraction_tools import load_probe_file, save_to_probe_file, write_to_binary_dat_format, get_sub_extractors_by_property
 
 class RecordingExtractor(ABC):
     '''A class that contains functions for extracting important information
@@ -617,7 +617,7 @@ class RecordingExtractor(ABC):
         save_to_probe_file(self, probe_file, format=format, radius=radius, dimensions=dimensions,
                            verbose=verbose)
 
-    def write_binary_dat_format(self, save_path, time_axis=0, dtype=None, chunksize=None):
+    def write_to_binary_dat_format(self, save_path, time_axis=0, dtype=None, chunksize=None):
         '''Saves the traces of this recording extractor into binary .dat format.
 
         Parameters
@@ -633,7 +633,7 @@ class RecordingExtractor(ABC):
             If not None then the copy done by chunk size.
             This avoid to much memory consumption for big files.
         '''
-        write_binary_dat_format(self, save_path=save_path, time_axis=time_axis, dtype=dtype, chunksize=chunksize)
+        write_to_binary_dat_format(self, save_path=save_path, time_axis=time_axis, dtype=dtype, chunksize=chunksize)
    
     def get_sub_extractors_by_property(self, property_name, return_property_list=False):
         '''Returns a list of SubRecordingExtractors from this RecordingExtractor based on the given
@@ -663,7 +663,7 @@ class RecordingExtractor(ABC):
             sub_list = get_sub_extractors_by_property(self, property_name=property_name, 
                                                       return_property_list=return_property_list)
             return sub_list
-            
+
     @classmethod
     def gui_params(self):
         return copy.deepcopy(self._gui_params)

--- a/spikeextractors/sortingextractor.py
+++ b/spikeextractors/sortingextractor.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 import numpy as np
 import copy
+from .extraction_tools import get_sub_extractors_by_property
+
 
 
 class SortingExtractor(ABC):
@@ -589,6 +591,32 @@ class SortingExtractor(ABC):
         from .subsortingextractor import SubSortingExtractor
         return SubSortingExtractor(parent_sorting=self, start_frame=start_frame,
                                    end_frame=end_frame)
+
+    def get_sub_extractors_by_property(self, property_name, return_property_list=False):
+        '''Returns a list of SubSortingExtractors from this SortingExtractor based on the given
+        property_name (e.g. group)
+
+        Parameters
+        ----------
+        property_name: str
+            The property used to subdivide the extractor
+        return_property_list: bool
+            If True the property list is returned
+
+        Returns
+        -------
+        sub_list: list
+            The list of subextractors to be returned.
+
+        '''
+        if return_property_list:
+            sub_list, prop_list = get_sub_extractors_by_property(self, property_name=property_name, 
+                                                                return_property_list=return_property_list)
+            return sub_list, prop_list
+        else:
+            sub_list = get_sub_extractors_by_property(self, property_name=property_name, 
+                                                      return_property_list=return_property_list)
+            return sub_list
 
     @classmethod
     def gui_params(self):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -20,16 +20,16 @@ class TestTools(unittest.TestCase):
         shutil.rmtree(self.test_dir)
 
     def test_load_save_probes(self):
-        SX = se.load_probe_file(self.RX, 'tests/probe_test.prb')
+        sub_RX = se.load_probe_file(self.RX, 'tests/probe_test.prb')
         # print(SX.get_channel_property_names())
-        assert 'location' in SX.get_shared_channel_property_names()
-        assert 'group' in SX.get_shared_channel_property_names()
-        positions = [SX.get_channel_property(chan, 'location') for chan in range(self.RX.get_num_channels())]
+        assert 'location' in sub_RX.get_shared_channel_property_names()
+        assert 'group' in sub_RX.get_shared_channel_property_names()
+        positions = [sub_RX.get_channel_property(chan, 'location') for chan in range(self.RX.get_num_channels())]
         # save in csv
-        se.save_probe_file(SX, Path(self.test_dir) / 'geom.csv')
+        sub_RX.save_to_probe_file(Path(self.test_dir) / 'geom.csv')
         # load csv locations
-        SX_load = se.load_probe_file(SX, Path(self.test_dir) / 'geom.csv')
-        position_loaded = [SX_load.get_channel_property(chan, 'location') for chan in range(SX_load.get_num_channels())]
+        sub_RX_load = sub_RX.load_probe_file(Path(self.test_dir) / 'geom.csv')
+        position_loaded = [sub_RX_load.get_channel_property(chan, 'location') for chan in range(sub_RX_load.get_num_channels())]
         self.assertTrue(np.allclose(positions[10], position_loaded[10]))
 
     def test_write_dat_file(self):
@@ -37,26 +37,26 @@ class TestTools(unittest.TestCase):
         nb_chan = self.RX.get_num_channels()
 
         # time_axis=0 chunksize=None
-        se.write_binary_dat_format(self.RX, self.test_dir + 'rec.dat', time_axis=0, dtype='float32', chunksize=None)
+        self.RX.write_binary_dat_format(self.test_dir + 'rec.dat', time_axis=0, dtype='float32', chunksize=None)
         data = np.memmap(open(self.test_dir + 'rec.dat'), dtype='float32', mode='r', shape=(nb_sample, nb_chan)).T
         assert np.allclose(data, self.RX.get_traces())
         del(data) # this close the file
 
         # time_axis=1 chunksize=None
-        se.write_binary_dat_format(self.RX, self.test_dir + 'rec.dat', time_axis=1, dtype='float32', chunksize=None)
+        self.RX.write_binary_dat_format(self.test_dir + 'rec.dat', time_axis=1, dtype='float32', chunksize=None)
         data = np.memmap(open(self.test_dir + 'rec.dat'), dtype='float32', mode='r', shape=(nb_chan, nb_sample))
         assert np.allclose(data, self.RX.get_traces())
         del(data) # this close the file
 
         # time_axis=0 chunksize=99
-        se.write_binary_dat_format(self.RX, self.test_dir + 'rec.dat', time_axis=0, dtype='float32', chunksize=99)
+        self.RX.write_binary_dat_format(self.test_dir + 'rec.dat', time_axis=0, dtype='float32', chunksize=99)
         data = np.memmap(open(self.test_dir + 'rec.dat'), dtype='float32', mode='r', shape=(nb_sample, nb_chan)).T
         assert np.allclose(data, self.RX.get_traces())
         del(data) # this close the file
 
         # time_axis=1 chunksize=99 do not work
         with self.assertRaises(Exception) as context:
-            se.write_binary_dat_format(self.RX, self.test_dir + 'rec.dat', time_axis=1, dtype='float32', chunksize=99)
+            self.RX.write_binary_dat_format(self.test_dir + 'rec.dat', time_axis=1, dtype='float32', chunksize=99)
 
 
 if __name__ == '__main__':

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -37,26 +37,26 @@ class TestTools(unittest.TestCase):
         nb_chan = self.RX.get_num_channels()
 
         # time_axis=0 chunksize=None
-        self.RX.write_binary_dat_format(self.test_dir + 'rec.dat', time_axis=0, dtype='float32', chunksize=None)
+        self.RX.write_to_binary_dat_format(self.test_dir + 'rec.dat', time_axis=0, dtype='float32', chunksize=None)
         data = np.memmap(open(self.test_dir + 'rec.dat'), dtype='float32', mode='r', shape=(nb_sample, nb_chan)).T
         assert np.allclose(data, self.RX.get_traces())
         del(data) # this close the file
 
         # time_axis=1 chunksize=None
-        self.RX.write_binary_dat_format(self.test_dir + 'rec.dat', time_axis=1, dtype='float32', chunksize=None)
+        self.RX.write_to_binary_dat_format(self.test_dir + 'rec.dat', time_axis=1, dtype='float32', chunksize=None)
         data = np.memmap(open(self.test_dir + 'rec.dat'), dtype='float32', mode='r', shape=(nb_chan, nb_sample))
         assert np.allclose(data, self.RX.get_traces())
         del(data) # this close the file
 
         # time_axis=0 chunksize=99
-        self.RX.write_binary_dat_format(self.test_dir + 'rec.dat', time_axis=0, dtype='float32', chunksize=99)
+        self.RX.write_to_binary_dat_format(self.test_dir + 'rec.dat', time_axis=0, dtype='float32', chunksize=99)
         data = np.memmap(open(self.test_dir + 'rec.dat'), dtype='float32', mode='r', shape=(nb_sample, nb_chan)).T
         assert np.allclose(data, self.RX.get_traces())
         del(data) # this close the file
 
         # time_axis=1 chunksize=99 do not work
         with self.assertRaises(Exception) as context:
-            self.RX.write_binary_dat_format(self.test_dir + 'rec.dat', time_axis=1, dtype='float32', chunksize=99)
+            self.RX.write_to_binary_dat_format(self.test_dir + 'rec.dat', time_axis=1, dtype='float32', chunksize=99)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Based off the meeting we had, I implemented extraction tools that are _internal_ to the RecordingExtractor and Sorting Extractor. Now you can call load_probe_file, save_to_probe_file, write_to_binary_dat_format, get_sub_extractors_by_property with:

```
recording.load_probe_file
recording.save_to_probe_file
recording.write_to_binary_dat_format
recording.get_sub_extractors_by_property
```
You can also call:

```
sorting.get_sub_extractors_by_property
```
I left the original functions in extraction_tools and the extractors call those original function internally. I added tests for them and they pass.

I changed two names as well:

save_probe_file --> save_to_probe_file
write_binary_dat_format --> write_to_binary_dat_format