### PR TITLE
Cache extractor

### DIFF
--- a/spikeextractors/__init__.py
+++ b/spikeextractors/__init__.py
@@ -1,5 +1,6 @@
 from .recordingextractor import RecordingExtractor
 from .sortingextractor import SortingExtractor
+from .cacherecordingextractor import CacheRecordingExtractor
 from .subsortingextractor import SubSortingExtractor
 from .subrecordingextractor import SubRecordingExtractor
 from .multirecordingchannelextractor import concatenate_recordings_by_channel, MultiRecordingChannelExtractor

--- a/spikeextractors/cacherecordingextractor.py
+++ b/spikeextractors/cacherecordingextractor.py
@@ -1,0 +1,18 @@
+from spikeextractors.extractors.bindatrecordingextractor import BinDatRecordingExtractor
+import tempfile
+
+
+class CacheRecordingExtractor(BinDatRecordingExtractor):
+
+    extractor_name = 'CacheRecordingExtractor'
+
+    def __init__(self, recording, dtype=None, chunksize=None):
+        tmp_file = tempfile.NamedTemporaryFile(suffix=".dat").name
+        if dtype is None:
+            dtype = recording.get_traces(start_frame=0, end_frame=2).dtype
+        recording.write_to_binary_dat_format(save_path=tmp_file, dtype=dtype, chunksize=chunksize)
+        BinDatRecordingExtractor.__init__(self, tmp_file, numchan=recording.get_num_channels(),
+                                          recording_channels=recording.get_channel_ids(),
+                                          sampling_frequency=recording.get_sampling_frequency(),
+                                          dtype=dtype)
+        self.copy_channel_properties(recording)

--- a/spikeextractors/cacherecordingextractor.py
+++ b/spikeextractors/cacherecordingextractor.py
@@ -1,5 +1,6 @@
 from spikeextractors.extractors.bindatrecordingextractor import BinDatRecordingExtractor
 import tempfile
+import os
 
 
 class CacheRecordingExtractor(BinDatRecordingExtractor):
@@ -7,12 +8,15 @@ class CacheRecordingExtractor(BinDatRecordingExtractor):
     extractor_name = 'CacheRecordingExtractor'
 
     def __init__(self, recording, dtype=None, chunksize=None):
-        tmp_file = tempfile.NamedTemporaryFile(suffix=".dat").name
+        self._tmp_file = tempfile.NamedTemporaryFile(suffix=".dat").name
         if dtype is None:
             dtype = recording.get_traces(start_frame=0, end_frame=2).dtype
-        recording.write_to_binary_dat_format(save_path=tmp_file, dtype=dtype, chunksize=chunksize)
-        BinDatRecordingExtractor.__init__(self, tmp_file, numchan=recording.get_num_channels(),
+        recording.write_to_binary_dat_format(save_path=self._tmp_file, dtype=dtype, chunksize=chunksize)
+        BinDatRecordingExtractor.__init__(self, self._tmp_file, numchan=recording.get_num_channels(),
                                           recording_channels=recording.get_channel_ids(),
                                           sampling_frequency=recording.get_sampling_frequency(),
                                           dtype=dtype)
         self.copy_channel_properties(recording)
+
+    def __del__(self):
+        os.remove(self._tmp_file)


### PR DESCRIPTION
Implemented a CacheRecordingExtractor. It takes a recording as input and it inherits from a BinDatRecordingExtractor.

When the object is deleted the temporary file is removed