### PR TITLE
New recording extractor for nixio (nixpy)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 python:
 - '3.6'
 install:
-- pip install mountainlab_pytools pynwb pyopenephys kbucket h5py MEArec exdir ruamel.yaml
+- pip install mountainlab_pytools pynwb pyopenephys kbucket h5py MEArec exdir ruamel.yaml nixio
 - pip install .
 - pip install pytest
 script: pytest

--- a/spikeextractors/extractorlist.py
+++ b/spikeextractors/extractorlist.py
@@ -18,6 +18,7 @@ from .extractors.spikeglxrecordingextractor.spikeglxrecordingextractor import Sp
 from .extractors.tridescloussortingextractor.tridescloussortingextractor import TridesclousSortingExtractor
 from .extractors.npzsortingextractor.npzsortingextractor import NpzSortingExtractor
 from .extractors.mcsh5recordingextractor.mcsh5recordingextractor import MCSH5RecordingExtractor
+from .extractors.nixiorecordingextractor.nixiorecordingextractor import NIXIORecordingExtractor
 
 
 recording_extractor_full_list = [
@@ -34,7 +35,8 @@ recording_extractor_full_list = [
     SpikeGLXRecordingExtractor,
     PhyRecordingExtractor,
     MaxOneRecordingExtractor,
-    MCSH5RecordingExtractor
+    MCSH5RecordingExtractor,
+    NIXIORecordingExtractor,
 ]
 
 recording_extractor_dict = {recording_class.extractor_name: recording_class for recording_class in recording_extractor_full_list}

--- a/spikeextractors/extractors/nixiorecordingextractor/__init__.py
+++ b/spikeextractors/extractors/nixiorecordingextractor/__init__.py
@@ -1,0 +1,1 @@
+from .nixiorecordingextractor import NIXIORecordingExtractor

--- a/spikeextractors/extractors/nixiorecordingextractor/nixiorecordingextractor.py
+++ b/spikeextractors/extractors/nixiorecordingextractor/nixiorecordingextractor.py
@@ -52,38 +52,6 @@ class NIXIORecordingExtractor(RecordingExtractor):
         return sampling_frequency
 
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        '''This function extracts and returns a trace from the recorded data
-        from the given channels ids and the given start and end frame. It will
-        return traces from within three ranges:
-
-            [start_frame, t_start+1, ..., end_frame-1]
-            [start_frame, start_frame+1, ..., final_recording_frame - 1]
-            [0, 1, ..., end_frame-1]
-            [0, 1, ..., final_recording_frame - 1]
-
-        If both start_frame and end_frame are given, if only start_frame is
-        given, if only end_frame is given, or if neither start_frame or
-        end_frame are given, respectively. Traces are returned in a 2D array
-        that contains all of the traces from each channel with dimensions
-        (num_channels x num_frames). In this implementation, start_frame is
-        inclusive and end_frame is exclusive conforming to numpy standards.
-
-        Parameters
-        ----------
-        start_frame: int
-            The starting frame of the trace to be returned (inclusive).
-        end_frame: int
-            The ending frame of the trace to be returned (exclusive).
-        channel_ids: array_like
-            A list or 1D array of channel ids (ints) from which each trace
-            will be extracted.
-
-        Returns
-        ----------
-        traces: numpy.ndarray
-            A 2D array that contains all of the traces from each channel.
-            Dimensions are: (num_channels x num_frames)
-        '''
         if channel_ids:
             channels = np.array([self._traces[cid] for cid in channel_ids])
         else:
@@ -92,12 +60,6 @@ class NIXIORecordingExtractor(RecordingExtractor):
 
     @staticmethod
     def write_recording(recording, save_path, overwrite=False):
-        '''
-        This is an example of a function that is not abstract so it is
-        optional if you want to override it.  It allows other
-        RecordingExtractor to use your new RecordingExtractor to convert their
-        recorded data into your recording file format.
-        '''
         if not HAVE_NIXIO:
             raise ImportError(missing_nixio_msg)
         if os.path.exists(save_path) and not overwrite:

--- a/spikeextractors/extractors/nixiorecordingextractor/nixiorecordingextractor.py
+++ b/spikeextractors/extractors/nixiorecordingextractor/nixiorecordingextractor.py
@@ -106,7 +106,10 @@ class NIXIORecordingExtractor(RecordingExtractor):
         da = block.create_data_array("traces", "spikeinterface.traces",
                                      data=recording.get_traces())
         labels = recording.get_channel_ids()
-        da.append_set_dimension(labels=labels)
+        if not labels:  # channel IDs not specified; just number them
+            labels = list(range(recording.get_num_channels()))
+        chandim = da.append_set_dimension()
+        chandim.labels = labels
         sfreq = recording.get_sampling_frequency()
         da.append_sampled_dimension(sampling_interval=1./sfreq, unit="s")
         nf.close()

--- a/spikeextractors/extractors/nixiorecordingextractor/nixiorecordingextractor.py
+++ b/spikeextractors/extractors/nixiorecordingextractor/nixiorecordingextractor.py
@@ -1,4 +1,5 @@
 import os
+import numpy as np
 try:
     import nixio as nix
     HAVE_NIXIO = True
@@ -83,7 +84,10 @@ class NIXIORecordingExtractor(RecordingExtractor):
             A 2D array that contains all of the traces from each channel.
             Dimensions are: (num_channels x num_frames)
         '''
-        channels = self._traces[channel_ids]
+        if channel_ids:
+            channels = np.array([self._traces[cid] for cid in channel_ids])
+        else:
+            channels = self._traces[:]
         return channels[:, start_frame:end_frame]
 
     @staticmethod
@@ -111,5 +115,7 @@ class NIXIORecordingExtractor(RecordingExtractor):
         chandim = da.append_set_dimension()
         chandim.labels = labels
         sfreq = recording.get_sampling_frequency()
-        da.append_sampled_dimension(sampling_interval=1./sfreq, unit="s")
+        timedim = da.append_sampled_dimension(sampling_interval=1./sfreq)
+        timedim.unit = "s"
+
         nf.close()

--- a/spikeextractors/extractors/nixiorecordingextractor/nixiorecordingextractor.py
+++ b/spikeextractors/extractors/nixiorecordingextractor/nixiorecordingextractor.py
@@ -1,0 +1,91 @@
+import numpy as np
+try:
+    import nixio as nix
+    HAVE_NIXIO = True
+except ImportError:
+    HAVE_NIXIO = False
+
+from ...recordingextractor import RecordingExtractor
+
+
+class NIXIORecordingExtractor(RecordingExtractor):
+
+    extractor_name = 'NIXIORecordingExtractor'
+    installed = HAVE_NIXIO  # check at class level if installed or not
+    is_writable = True
+    mode = 'file'
+    # error message when not installed
+    installation_mesg = ("To use the NIXIORecordingExtractor install nixio:"
+                         "\n\n pip install nixio\n\n")
+
+    def __init__(self, arg):
+        RecordingExtractor.__init__(self)
+        # All file specific initialization code can go here.
+
+    def get_channel_ids(self):
+        # Fill code to get a list of channel_ids. If channel ids are not
+        # specified, you can use: channel_ids = range(num_channels)
+        channel_ids = list()
+        return channel_ids
+
+    def get_num_frames(self):
+        # Fill code to get the number of frames (samples) in the recordings.
+        num_frames = 0
+        return num_frames
+
+    def get_sampling_frequency(self, unit_id, start_frame=None,
+                               end_frame=None):
+        # Fill code to get the sampling frequency of the recordings.
+        sampling_frequency = 0
+        return sampling_frequency
+
+    def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
+        '''This function extracts and returns a trace from the recorded data
+        from the given channels ids and the given start and end frame. It will
+        return traces from within three ranges:
+
+            [start_frame, t_start+1, ..., end_frame-1]
+            [start_frame, start_frame+1, ..., final_recording_frame - 1]
+            [0, 1, ..., end_frame-1]
+            [0, 1, ..., final_recording_frame - 1]
+
+        If both start_frame and end_frame are given, if only start_frame is
+        given, if only end_frame is given, or if neither start_frame or
+        end_frame are given, respectively. Traces are returned in a 2D array
+        that contains all of the traces from each channel with dimensions
+        (num_channels x num_frames). In this implementation, start_frame is
+        inclusive and end_frame is exclusive conforming to numpy standards.
+
+        Parameters
+        ----------
+        start_frame: int
+            The starting frame of the trace to be returned (inclusive).
+        end_frame: int
+            The ending frame of the trace to be returned (exclusive).
+        channel_ids: array_like
+            A list or 1D array of channel ids (ints) from which each trace
+            will be extracted.
+
+        Returns
+        ----------
+        traces: numpy.ndarray
+            A 2D array that contains all of the traces from each channel.
+            Dimensions are: (num_channels x num_frames)
+        '''
+        # Fill code to get the traces of the specified channel_ids, from
+        # start_frame to end_frame
+        traces = np.zeros((0, 0))
+        return traces
+
+    # Optional functions and pre-implemented functions that a new
+    # RecordingExtractor doesn't need to implement
+
+    @staticmethod
+    def write_recording(recording, save_path):
+        '''
+        This is an example of a function that is not abstract so it is
+        optional if you want to override it.  It allows other
+        RecordingExtractor to use your new RecordingExtractor to convert their
+        recorded data into your recording file format.
+        '''
+        pass

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -196,7 +196,7 @@ class TestExtractors(unittest.TestCase):
         RX_sub = RX_multi.get_epoch('C')
         self._check_recordings_equal(self.RX, RX_sub)
         self.assertEqual(4, len(RX_sub.get_channel_ids()))
-        
+
         RX_multi = se.MultiRecordingChannelExtractor(
             recordings=[self.RX, self.RX2, self.RX3],
             groups=[1, 2, 3]
@@ -223,6 +223,17 @@ class TestExtractors(unittest.TestCase):
         )
         SX_sub1 = se.SubSortingExtractor(parent_sorting=SX_multi, start_frame=0, end_frame=N)
         self._check_sortings_equal(SX_multi, SX_sub1)
+
+    def test_nixio_extractor(self):
+        path1 = os.path.join(self.test_dir, 'raw.nix')
+        se.NIXIORecordingExtractor.write_recording(self.RX, path1)
+        RX_nixio = se.NIXIORecordingExtractor(path1)
+        self._check_recording_return_types(RX_nixio)
+        self._check_recordings_equal(self.RX, RX_nixio)
+        del RX_nixio
+        # test force overwrite
+        se.NIXIORecordingExtractor.write_recording(self.RX, path1,
+                                                   overwrite=True)
 
     def _check_recordings_equal(self, RX1, RX2):
         M = RX1.get_num_channels()


### PR DESCRIPTION
This PR adds the NIXIORecordingExtractor for writing to and reading from NIX files using [NIXPy](https://github.com/G-Node/nixpy).  Initial discussion about including NIX can be found in [this issue](https://github.com/G-Node/nixpy/issues/413).

This is an initial attempt based on the contribution guide, the API docs, and the test (adapted from the other RecordingExtractor tests as discussed in the issue linked above).  If it looks like the writer or reader are doing anything out of the ordinary of unexpected, let me know, since I'm not very familiar with SpikeInterface in general.

### Some notes on the implementation
- The `get_traces()` method is a little strange looking and inefficient.  The indexing in NIXPy isn't very flexible in the latest stable release (1.4.9).  The current beta (1.5.0b3) allows fancy indexing like in NumPy and h5py but I didn't want to make the extractor depend on a beta release.  We can clean it up when 1.5.0 gets a stable release.
- At the top level of a NIX file there must always be one or more Block objects.  I used the provided file name to name the Block.  If a file is renamed this wont change the Block name, but the name is inconsequential.  The name can be used to access the Block and it appears when printing but beyond that it has no function.  If there's a better name for it, or if there is some convention in the library, I'd prefer to use that.
- Traces are stored in a DataArray directly as received by the write function.  The DataArray gets one SetDimension, which represents the first dimension (the channels), and a SampledDimension, which represents the second dimension of the data (time).  

### Questions
- The time dimension's units are set as seconds.  Is this correct?  Is it implied that the sampling frequency is in Hz?
- Should the unit of the data be set to volts?  Leaving it undefined (as it is now) wont cause any issues, but for consistency and completeness, it might be better to set it if this is the implied unit of the traces.

---

If this looks good, I'll take a look at writing a SortingExtractor for NIX as well.