### PR TITLE
Force spike trains to be int64

### DIFF
--- a/spikeextractors/extractors/npzsortingextractor/npzsortingextractor.py
+++ b/spikeextractors/extractors/npzsortingextractor/npzsortingextractor.py
@@ -48,7 +48,7 @@ class NpzSortingExtractor(SortingExtractor):
             spike_times = spike_times[spike_times >= start_frame]
         if end_frame is not None:
             spike_times = spike_times[spike_times < end_frame]
-        return spike_times
+        return spike_times.astype('int64')
 
     @staticmethod
     def write_sorting(sorting, save_path):

--- a/spikeextractors/extractors/spykingcircusextractors/spykingcircusextractors.py
+++ b/spikeextractors/extractors/spykingcircusextractors/spykingcircusextractors.py
@@ -61,10 +61,11 @@ class SpykingCircusSortingExtractor(SortingExtractor):
     is_writable = True
     mode = 'folder'
     exporter_gui_params = [
-        {'name': 'save_path', 'type': 'file_or_folder', 'title': "Path to file or folder (file must end with is either a folder or an hdf5 file ending with 'result.hdf5' or 'result-merged.hdf5'"},
+        {'name': 'save_path', 'type': 'file_or_folder', 'title': "Path to file or folder (file must end with is either"
+                                                                 " a folder or an hdf5 file ending with 'result.hdf5'"
+                                                                 " or 'result-merged.hdf5'"},
     ]
     installation_mesg = "To use the SpykingCircusSortingExtractor install h5py: \n\n pip install h5py\n\n"
-                               # error message when not installed
 
     def __init__(self, folder_path):
         assert HAVE_SCSX, "To use the SpykingCircusSortingExtractor install h5py: \n\n pip install h5py\n\n"
@@ -113,7 +114,7 @@ class SpykingCircusSortingExtractor(SortingExtractor):
         self._spiketrains = []
         self._unit_ids = []
         for temp in f_results['spiketimes'].keys():
-            self._spiketrains.append(f_results['spiketimes'][temp])
+            self._spiketrains.append(np.array(f_results['spiketimes'][temp]).astype('int64'))
             self._unit_ids.append(int(temp.split('_')[-1]))
 
     def get_unit_ids(self):
@@ -124,7 +125,7 @@ class SpykingCircusSortingExtractor(SortingExtractor):
             start_frame = 0
         if end_frame is None:
             end_frame = np.Inf
-        times = np.array(self._spiketrains[self.get_unit_ids().index(unit_id)])
+        times = self._spiketrains[self.get_unit_ids().index(unit_id)]
         inds = np.where((start_frame <= times) & (times < end_frame))
         return times[inds]
 


### PR DESCRIPTION
- spykingcircus loaded spiketrains in uint32, causing problems in downstream comparisons
- also force int64 to NPZ