### PR TITLE
New sorting extractor for nixio

### DIFF
--- a/spikeextractors/extractorlist.py
+++ b/spikeextractors/extractorlist.py
@@ -18,7 +18,7 @@ from .extractors.spikeglxrecordingextractor.spikeglxrecordingextractor import Sp
 from .extractors.tridescloussortingextractor.tridescloussortingextractor import TridesclousSortingExtractor
 from .extractors.npzsortingextractor.npzsortingextractor import NpzSortingExtractor
 from .extractors.mcsh5recordingextractor.mcsh5recordingextractor import MCSH5RecordingExtractor
-from .extractors.nixiorecordingextractor.nixiorecordingextractor import NIXIORecordingExtractor
+from .extractors.nixioextractors.nixioextractors import NIXIORecordingExtractor, NIXIOSortingExtractor
 
 
 recording_extractor_full_list = [
@@ -54,6 +54,7 @@ sorting_extractor_full_list = [
     SpykingCircusSortingExtractor,
     TridesclousSortingExtractor,
     NpzSortingExtractor,
+    NIXIOSortingExtractor,
 ]
 
 installed_sorting_extractor_list = [sx for sx in sorting_extractor_full_list if sx.installed]

--- a/spikeextractors/extractors/nixioextractors/__init__.py
+++ b/spikeextractors/extractors/nixioextractors/__init__.py
@@ -1,0 +1,1 @@
+from .nixioextractors import NIXIORecordingExtractor, NIXIOSortingExtractor

--- a/spikeextractors/extractors/nixioextractors/nixioextractors.py
+++ b/spikeextractors/extractors/nixioextractors/nixioextractors.py
@@ -188,7 +188,9 @@ class NIXIOSortingExtractor(SortingExtractor):
             raise FileExistsError("File exists: {}".format(save_path))
 
         sfreq = sorting.get_sampling_frequency()
-        if sfreq == 1:
+        if sfreq is None:
+            unit = None
+        elif sfreq == 1:
             unit = "s"
         else:
             unit = "{} s".format(1./sfreq)

--- a/spikeextractors/extractors/nixioextractors/nixioextractors.py
+++ b/spikeextractors/extractors/nixioextractors/nixioextractors.py
@@ -127,11 +127,11 @@ class NIXIORecordingExtractor(RecordingExtractor):
                                       "spikeinterface.properties")
         da.metadata = traces_md
         channels = recording.get_channel_ids()
-        for chanid in channels:
-            chan_md = traces_md.create_section(str(chanid),
+        for chan_id in channels:
+            chan_md = traces_md.create_section(str(chan_id),
                                                "spikeinterface.properties")
-            for propname in recording.get_channel_property_names(chanid):
-                propvalue = recording.get_channel_property(chanid, propname)
+            for propname in recording.get_channel_property_names(chan_id):
+                propvalue = recording.get_channel_property(chan_id, propname)
                 if nf.version <= (1, 1, 0):
                     if isinstance(propvalue, Iterable):
                         values = list(map(nix.Value, propvalue))
@@ -236,11 +236,11 @@ class NIXIOSortingExtractor(SortingExtractor):
             da.metadata = spikes_md
 
         units = sorting.get_unit_ids()
-        for uid in units:
-            unit_md = spikes_md.create_section(str(uid),
+        for unit_id in units:
+            unit_md = spikes_md.create_section(str(unit_id),
                                                "spikeinterface.properties")
-            for propname in sorting.get_unit_property_names(uid):
-                propvalue = sorting.get_unit_property(uid, propname)
+            for propname in sorting.get_unit_property_names(unit_id):
+                propvalue = sorting.get_unit_property(unit_id, propname)
                 if nf.version <= (1, 1, 0):
                     if isinstance(propvalue, Iterable):
                         values = list(map(nix.Value, propvalue))

--- a/spikeextractors/extractors/nixiorecordingextractor/__init__.py
+++ b/spikeextractors/extractors/nixiorecordingextractor/__init__.py
@@ -1,1 +1,0 @@
-from .nixiorecordingextractor import NIXIORecordingExtractor

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -235,6 +235,12 @@ class TestExtractors(unittest.TestCase):
         se.NIXIORecordingExtractor.write_recording(self.RX, path1,
                                                    overwrite=True)
 
+        path2 = self.test_dir + '/firings_true.nix'
+        se.NIXIOSortingExtractor.write_sorting(self.SX, path2)
+        SX_mearec = se.NIXIOSortingExtractor(path2)
+        self._check_sorting_return_types(SX_mearec)
+        self._check_sortings_equal(self.SX, SX_mearec)
+
     def _check_recordings_equal(self, RX1, RX2):
         M = RX1.get_num_channels()
         N = RX1.get_num_frames()


### PR DESCRIPTION
This PR adds the NIXIOSortingExtractor for writing sorted spikes to and reading from NIX files.  The file and module have been renamed from `nixiorecordingextractor` to `nixioextractors` since they now contain both kinds of extractors.

I also added support for writing and reading unit properties, just like with the NIXIORecordingExtractor.