### PR TITLE
When single group make sure group id is not 0

### DIFF
--- a/spikeextractors/extractors/exdirextractors/exdirextractors.py
+++ b/spikeextractors/extractors/exdirextractors/exdirextractors.py
@@ -289,7 +289,7 @@ class ExdirSortingExtractor(SortingExtractor):
         else:
             channel_groups = [0]
 
-        if len(channel_groups) == 1:
+        if len(channel_groups) == 1 and channel_groups[0] == 0:
             chan = 0
             if verbose:
                 print("Single group: ", chan)


### PR DESCRIPTION
This fixes a bug in the ExdirSortingExtractor.write_sorting().

If groups are available and units are found only in one group, it saves in the proper channel folder.