### PR TITLE
Refractor save_to_probe_file

### DIFF
--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -626,20 +626,27 @@ class RecordingExtractor(ABC):
                                        channel_groups=channel_groups, verbose=verbose)
         return subrecording
 
-    def save_to_probe_file(self, probe_file, format=None, radius=100, dimensions=None, verbose=False):
+    def save_to_probe_file(self, probe_file, grouping_property=None, radius=None,
+                           graph=True, geometry=True, verbose=False):
         '''Saves probe file from the channel information of this recording extractor.
 
         Parameters
         ----------
         probe_file: str
             file name of .prb or .csv file to save probe information to
-        format: str (optional)
-            Format for .prb file. It can be either 'klusta' or 'spyking_circus'. Default is None.
+        grouping_property: str (default None)
+            If grouping_property is a shared_channel_property, different groups are saved based on the property.
+        radius: float (default None)
+            Adjacency radius (used by some sorters). If None it is not saved to the probe file.
+        graph: bool
+            If True, the adjacency graph is saved (default=True)
+        geometry: bool
+            If True, the geometry is saved (default=True)
         verbose: bool
             If True, output is verbose
         '''
-        save_to_probe_file(self, probe_file, format=format, radius=radius, dimensions=dimensions,
-                           verbose=verbose)
+        save_to_probe_file(self, probe_file, grouping_property=grouping_property, radius=radius,
+                           graph=graph, geometry=geometry, verbose=verbose)
 
     def write_to_binary_dat_format(self, save_path, time_axis=0, dtype=None, chunk_size=None):
         '''Saves the traces of this recording extractor into binary .dat format.


### PR DESCRIPTION
This is to enforce writing of groups only when selected by the user (especially for spike sorting)

- added `grouping_property`
- removed `format` and added `graph`, `geometry`

