### PR TITLE
Nwb refactor metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 python:
 - '3.6'
 install:
-- pip install mountainlab_pytools pynwb==1.1.2 pyopenephys kbucket h5py MEArec exdir ruamel.yaml nixio shybrid
+- pip install mountainlab_pytools pynwb==1.3.0 pyopenephys kbucket h5py MEArec exdir ruamel.yaml nixio shybrid
 - pip install .
 - pip install pytest==3.6
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 python:
 - '3.6'
 install:
-- pip install mountainlab_pytools pynwb==1.3.0 pyopenephys kbucket h5py MEArec exdir ruamel.yaml nixio shybrid
+- pip install mountainlab_pytools pynwb==1.2.1 pyopenephys kbucket h5py MEArec exdir ruamel.yaml nixio shybrid
 - pip install .
 - pip install pytest==3.6
 script: pytest

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -382,7 +382,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                          if 'gain' in recording.get_channel_property_names(channel_id=ch) else 1
                          for ch in channel_ids])
                 if len(np.unique(gains)) == 1:  # if all gains are equal
-                    scalar_conversion = np.unique(gains)*1e-6
+                    scalar_conversion = np.unique(gains)[0]*1e-6
                     channel_conversion = None
                 else:
                     scalar_conversion = 1.

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -55,7 +55,7 @@ def set_dynamic_table_property(dynamic_table, row_ids, property_name, values, in
     else:
         if property_name in dynamic_table:
             # TODO
-            pass
+            raise NotImplementedError
         else:
             dynamic_table.add_column(
                 name=property_name,
@@ -331,6 +331,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                 rx_channel_properties = recording.get_channel_property_names(channel_id=ch)
                 for pr in rx_channel_properties:
                     val = recording.get_channel_property(ch, pr)
+                    desc = 'no description'
                     # property 'location' of RX channels corresponds to x, y, z of NWB electrodes
                     if pr == 'location':
                         names = ['x', 'y', 'z']
@@ -341,7 +342,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                                 property_name=nm,
                                 values=[float(v)],
                                 default_value=np.nan,
-                                description='no description'
+                                description=nm+' coordinate location on the implant'
                             )
                         continue
                     # group property of electrodes can not be updated
@@ -350,13 +351,14 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                     # property 'brain_area' of RX channels corresponds to 'location' of NWB electrodes
                     if pr == 'brain_area':
                         pr = 'location'
+                        desc = 'brain area location'
                     set_dynamic_table_property(
                         dynamic_table=electrode_table,
                         row_ids=[ch],
                         property_name=pr,
                         values=[val],
                         default_value=np.nan,
-                        description='no description'
+                        description=desc
                     )
 
             # Tests if ElectricalSeries already exists in acquisition

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -267,6 +267,10 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         else:
             read_mode = 'w'
 
+        # Update any previous metadata with user passed dictionary
+        if hasattr(recording, 'nwb_metadata'):
+            metadata = recording.nwb_metadata.update(metadata)
+
         with NWBHDF5IO(save_path, mode=read_mode) as io:
             if read_mode == 'r+':
                 nwbfile = io.read()

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -337,6 +337,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                     'location': 'electrode_group_location',
                     'device': metadata['Ecephys']['Device'][0]['name']
                 })
+
         # Tests if electrode groups exist in nwbfile, if not create them from metadata
         for grp in metadata['Ecephys']['ElectrodeGroup']:
             if str(grp['name']) not in nwbfile.electrode_groups:
@@ -362,8 +363,8 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             nwb_elec_ids = []
 
         # Extractors channel groups must be integers, but Nwb electrodes group_name can be strings
-        # Number code for Nwb electrodes groups
-        nwb_groups_names = [str(grp['name']) for grp in metadata['Ecephys']['ElectrodeGroup']]
+        # nwb_groups_names = [str(grp['name']) for grp in metadata['Ecephys']['ElectrodeGroup']]
+        nwb_groups_names = list(nwbfile.electrode_groups.keys())
 
         # For older versions of pynwb, we need to manually add these columns
         if pynwb.__version__ < '1.3.0':
@@ -382,14 +383,17 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                         location = np.append(location, [0])
                 else:
                     location = [np.nan, np.nan]
-                impedence = -1.0
-                grp_name = recording.get_channel_groups(channel_ids=[m])
-                grp = nwbfile.electrode_groups[nwb_groups_names[grp_name[0]]]
+                if 'group' in recording.get_channel_property_names(m):
+                    grp_name = recording.get_channel_groups(channel_ids=[m])
+                    grp = nwbfile.electrode_groups[nwb_groups_names[grp_name[0]]]
+                else:
+                    grp = nwbfile.electrode_groups[nwb_groups_names[0]]
+                impedance = -1.0
                 nwbfile.add_electrode(
                     id=m,
                     x=np.nan, y=np.nan, z=np.nan,
                     rel_x=float(location[0]), rel_y=float(location[1]),
-                    imp=impedence,
+                    imp=impedance,
                     location='unknown',
                     filtering='none',
                     group=grp,

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -275,31 +275,24 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             else:
                 device = nwbfile.create_device(name='Device')
 
-            # Check if 'groups' property exist for channels in Recording
+            # Check if 'groups' property exists for channels in Recording
             if 'group' in recording.get_shared_channel_property_names():
                 el_groups_names = np.unique(recording.get_channel_groups()).tolist()
-                # Creates electrode groups for groups names in Recording
-                for grp_name in el_groups_names:
-                    if str(grp_name) not in nwbfile.electrode_groups:
-                        elec_group = nwbfile.create_electrode_group(
-                            name=str(grp_name),
-                            location="electrode_group_location",
-                            device=device,
-                            description="electrode_group_description"
-                        )
             else:
-                if "0" not in nwbfile.electrode_groups:
-                    elec_group = nwbfile.create_electrode_group(
-                        name="0",
-                        location="electrode_group_location",
-                        device=device,
-                        description="electrode_group_description"
-                    )
+                el_groups_names = ["0"]
                 # Electrode groups are required for NWB, for consistency we create group for Recording channels
                 ids = recording.get_channel_ids()
                 vals = [0] * len(ids)
                 recording.set_channel_groups(channel_ids=ids, groups=vals)
-
+            # Creates electrode groups for groups names in Recording
+            for grp_name in el_groups_names:
+                if str(grp_name) not in nwbfile.electrode_groups:
+                    elec_group = nwbfile.create_electrode_group(
+                        name=str(grp_name),
+                        location="electrode_group_location",
+                        device=device,
+                        description="electrode_group_description"
+                    )
 
             # Check for existing electrodes
             if nwbfile.electrodes is not None:

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -173,6 +173,10 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             else:
                 gains = es.conversion * np.ones(num_channels) * 1e6
 
+            # Extractors channel groups must be integers, but Nwb electrodes group_name can be strings
+            if 'group_name' in nwbfile.electrodes.colnames:
+                unique_grp_names = list(np.unique(nwbfile.electrodes['group_name'][:]))
+
             # Fill channel properties dictionary from electrodes table
             self.channel_ids = es.electrodes.table.id[:]
             self._channel_properties = defaultdict(dict)
@@ -187,7 +191,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                     if isinstance(nwbfile.electrodes[col][ind], ElectrodeGroup):
                         continue
                     elif col == 'group_name':
-                        self._channel_properties[i]['group'] = int(nwbfile.electrodes[col][ind])
+                        self._channel_properties[i]['group'] = int(unique_grp_names.index(nwbfile.electrodes[col][ind]))
                     elif col == 'location':
                         self._channel_properties[i]['brain_area'] = nwbfile.electrodes[col][ind]
                     elif col in ['x', 'y', 'z']:

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -224,36 +224,38 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                     for _, row in df_epochs.iterrows()}
 
             self._kwargs = {'file_path': str(Path(file_path).absolute()), 'electrical_series_name': electrical_series_name}
+            self.make_nwb_metadata(nwbfile=nwbfile, es=es)
 
-            # Metadata dictionary - useful for constructing a nwb file
-            self.nwb_metadata = dict()
-            self.nwb_metadata['NWBFile'] = {
-                'session_description': nwbfile.session_description,
-                'identifier': nwbfile.identifier,
-                'session_start_time': nwbfile.session_start_time,
-                'institution': nwbfile.institution,
-                'lab': nwbfile.lab
-            }
-            self.nwb_metadata['Ecephys'] = dict()
-            # Update metadata with Device info
-            self.nwb_metadata['Ecephys']['Device'] = []
-            for dev in nwbfile.devices:
-                self.nwb_metadata['Ecephys']['Device'].append({'name': dev})
-            # Update metadata with ElectrodeGroup info
-            self.nwb_metadata['Ecephys']['ElectrodeGroup'] = []
-            for k, v in nwbfile.electrode_groups.items():
-                self.nwb_metadata['Ecephys']['ElectrodeGroup'].append({
-                    'name': v.name,
-                    'description': v.description,
-                    'location': v.location,
-                    'device': v.device.name
-                })
-            # Update metadata with ElectricalSeries info
-            self.nwb_metadata['Ecephys']['ElectricalSeries'] = []
-            self.nwb_metadata['Ecephys']['ElectricalSeries'].append({
-                'name': es.name,
-                'description': es.description
+    def make_nwb_metadata(self, nwbfile, es):
+        # Metadata dictionary - useful for constructing a nwb file
+        self.nwb_metadata = dict()
+        self.nwb_metadata['NWBFile'] = {
+            'session_description': nwbfile.session_description,
+            'identifier': nwbfile.identifier,
+            'session_start_time': nwbfile.session_start_time,
+            'institution': nwbfile.institution,
+            'lab': nwbfile.lab
+        }
+        self.nwb_metadata['Ecephys'] = dict()
+        # Update metadata with Device info
+        self.nwb_metadata['Ecephys']['Device'] = []
+        for dev in nwbfile.devices:
+            self.nwb_metadata['Ecephys']['Device'].append({'name': dev})
+        # Update metadata with ElectrodeGroup info
+        self.nwb_metadata['Ecephys']['ElectrodeGroup'] = []
+        for k, v in nwbfile.electrode_groups.items():
+            self.nwb_metadata['Ecephys']['ElectrodeGroup'].append({
+                'name': v.name,
+                'description': v.description,
+                'location': v.location,
+                'device': v.device.name
             })
+        # Update metadata with ElectricalSeries info
+        self.nwb_metadata['Ecephys']['ElectricalSeries'] = []
+        self.nwb_metadata['Ecephys']['ElectricalSeries'].append({
+            'name': es.name,
+            'description': es.description
+        })
 
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         check_nwb_install()

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -279,7 +279,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         return self.channel_ids.tolist()
 
     @staticmethod
-    def write_recording(recording, save_path, metadata={}):
+    def write_recording(recording, save_path, metadata=None):
         '''
 
         Parameters
@@ -297,6 +297,9 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             read_mode = 'r+'
         else:
             read_mode = 'w'
+
+        if metadata is None:
+            metadata = dict()
 
         # Update any previous metadata with user passed dictionary
         if hasattr(recording, 'nwb_metadata'):

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -211,8 +211,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                         'identifier': nwbfile.identifier,
                         'session_start_time': nwbfile.session_start_time,
                         'institution': nwbfile.institution,
-                        'lab': nwbfile.lab,
-                        'lab_meta_data': nwbfile.lab_meta_data
+                        'lab': nwbfile.lab
             }
             self.nwb_metadata['Ecephys'] = dict()
             # Update metadata with Device info

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -206,7 +206,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                         self._channel_properties[i]['group'] = int(unique_grp_names.index(nwbfile.electrodes[col][ind]))
                     elif col == 'location':
                         self._channel_properties[i]['brain_area'] = nwbfile.electrodes[col][ind]
-                    elif col in ['x', 'y', 'z']:
+                    elif col in ['x', 'y', 'z', 'rel_x', 'rel_y']:
                         continue
                     else:
                         self._channel_properties[i][col] = nwbfile.electrodes[col][ind]

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 from datetime import datetime
-from collections import defaultdict
+from collections import defaultdict, abc
 from pathlib import Path
 
 import numpy as np
@@ -14,9 +14,6 @@ try:
     from pynwb import NWBFile
     from pynwb.ecephys import ElectricalSeries
     from pynwb.ecephys import ElectrodeGroup
-    from pynwb.device import Device
-    from pynwb.misc import Units
-
     from hdmf.data_utils import DataChunkIterator
 
     HAVE_NWB = True
@@ -224,7 +221,8 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                     'start_frame': self.time_to_frame(row['start_time']),
                     'end_frame': self.time_to_frame(row['stop_time'])}
                     for _, row in df_epochs.iterrows()}
-        self._kwargs = {'file_path': str(Path(file_path).absolute()), 'electrical_series_name': electrical_series_name}
+
+            self._kwargs = {'file_path': str(Path(file_path).absolute()), 'electrical_series_name': electrical_series_name}
 
             # Metadata dictionary - useful for constructing a nwb file
             self.nwb_metadata = dict()
@@ -312,7 +310,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             metadata info for constructing the nwb file
         '''
         check_nwb_install()
-        n_channels = recording.get_num_channels()
+        # n_channels = recording.get_num_channels()
         channel_ids = recording.get_channel_ids()
 
         if os.path.exists(save_path):
@@ -367,7 +365,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             # Tests if electrode groups exist in nwbfile, if not create them from metadata
             for grp in metadata['Ecephys']['ElectrodeGroup']:
                 if str(grp['name']) not in nwbfile.electrode_groups:
-                    elec_group = nwbfile.create_electrode_group(
+                    nwbfile.create_electrode_group(
                         name=str(grp['name']),
                         location=grp['location'],
                         device=nwbfile.devices[grp['device']],

--- a/spikeextractors/sortingextractor.py
+++ b/spikeextractors/sortingextractor.py
@@ -18,7 +18,7 @@ class SortingExtractor(ABC):
         self._unit_properties = {}
         self._unit_features = {}
         self._sampling_frequency = None
-        self.id = np.random.randint(low=0, high=9223372036854775807)
+        self.id = np.random.randint(low=0, high=9223372036854775807, dtype='int64')
 
     @abstractmethod
     def get_unit_ids(self):
@@ -155,7 +155,7 @@ class SortingExtractor(ABC):
                             start_frame = 0
                         if end_frame is None:
                             end_frame = np.inf
-                        spike_indices =  np.where(np.logical_and(spike_train >= start_frame, spike_train < end_frame)) 
+                        spike_indices =  np.where(np.logical_and(spike_train >= start_frame, spike_train < end_frame))
                         return self._unit_features[unit_id][feature_name][spike_indices]
                     else:
                         raise ValueError(str(feature_name) + " has not been added to unit " + str(unit_id))
@@ -216,7 +216,7 @@ class SortingExtractor(ABC):
                 raise ValueError(str(unit_id) + " is not a valid unit_id")
         else:
             raise ValueError(str(unit_id) + " must be an int")
-        
+
     def get_shared_unit_spike_feature_names(self, unit_ids=None):
         '''Get the intersection of unit feature names for a given set of units or for all units if unit_ids is None.
          Parameters
@@ -383,7 +383,7 @@ class SortingExtractor(ABC):
                 raise ValueError(str(unit_id) + " is not a valid unit id")
         else:
             raise TypeError(str(unit_id) + " must be an int")
-        
+
     def get_shared_unit_property_names(self, unit_ids=None):
         '''Get the intersection of unit property names for a given set of units or for all units if unit_ids is None.
          Parameters
@@ -608,11 +608,11 @@ class SortingExtractor(ABC):
 
         '''
         if return_property_list:
-            sub_list, prop_list = get_sub_extractors_by_property(self, property_name=property_name, 
+            sub_list, prop_list = get_sub_extractors_by_property(self, property_name=property_name,
                                                                 return_property_list=return_property_list)
             return sub_list, prop_list
         else:
-            sub_list = get_sub_extractors_by_property(self, property_name=property_name, 
+            sub_list = get_sub_extractors_by_property(self, property_name=property_name,
                                                       return_property_list=return_property_list)
             return sub_list
 

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -249,17 +249,15 @@ class TestExtractors(unittest.TestCase):
         self._check_recordings_equal(self.RX, RX_nwb)
         del RX_nwb
         # overwrite
-        se.NwbRecordingExtractor.write_recording(self.RX, path1, session_description='second',
-                                                 identifier='19475')
+        se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path1)
         RX_nwb = se.NwbRecordingExtractor(path1)
         self._check_recording_return_types(RX_nwb)
         self._check_recordings_equal(self.RX, RX_nwb)
         # add sorting to existing
-        se.NwbSortingExtractor.write_sorting(self.SX, path1)
+        se.NwbSortingExtractor.write_sorting(sorting=self.SX, save_path=path1)
         # create new
         path2 = self.test_dir + '/firings_true.nwb'
-        se.NwbSortingExtractor.write_sorting(self.SX, path2, session_description='second',
-                                             identifier='19475')
+        se.NwbSortingExtractor.write_sorting(sorting=self.SX, save_path=path2)
         SX_nwb = se.NwbSortingExtractor(path1)
         self._check_sortings_equal(self.SX, SX_nwb)
 


### PR DESCRIPTION
This refactor contains some changes that help us integrate NwbRecordingExtractor better with many of our current projects, plus some fixes:

- add metadata control to NwbExtractor. This allows the use of metadata file instructions for NWB file contruction, a practice we’ve been trying to promote. It is optional and the standard conversions recording <--> nwb should work just the same without it.

- breaks down the nwb file formatting code into smaller, nwb-class-specific static methods, which allows us to interact better with each step of the way if needed for more advanced cases. Again, it won’t alter the standard conversions recording <--> nwb.

- fix #320

- fix temporarily #323