### PR TITLE
Implement dump and load_extractor_from_json

### DIFF
--- a/spikeextractors/__init__.py
+++ b/spikeextractors/__init__.py
@@ -11,6 +11,6 @@ from .extractorlist import *
 
 from . import example_datasets
 from .extraction_tools import load_probe_file, save_to_probe_file, read_binary, write_to_binary_dat_format, \
-    get_sub_extractors_by_property
+    get_sub_extractors_by_property, load_extractor_from_json
 
 from .version import version as __version__

--- a/spikeextractors/__init__.py
+++ b/spikeextractors/__init__.py
@@ -11,6 +11,6 @@ from .extractorlist import *
 
 from . import example_datasets
 from .extraction_tools import load_probe_file, save_to_probe_file, read_binary, write_to_binary_dat_format, \
-    get_sub_extractors_by_property, load_extractor_from_json
+    get_sub_extractors_by_property, load_extractor_from_json, load_extractor_from_dict
 
 from .version import version as __version__

--- a/spikeextractors/baseextractor.py
+++ b/spikeextractors/baseextractor.py
@@ -19,11 +19,6 @@ class BaseExtractor:
         imported_module = importlib.import_module(module)
 
         if self.is_dumpable:
-            if 'CacheRecording' in class_name:
-                print("Warning: dumping a CacheRecordingExtractor. The path to the tmp binary file will be lost in "
-                      "further sessions. To prevent this, use the "
-                      "'CacheRecordingExtractor.save_to_file('path-to-file)' function")
-
             dump_dict = {'class': class_name, 'module': module, 'kwargs': self._kwargs,
                          'version': imported_module.__version__, 'dumpable': True}
 
@@ -211,18 +206,21 @@ def _check_json(d):
             if len(v_arr.shape) == 1:
                 if 'int' in str(v_arr.dtype):
                     v_arr = [int(v_el) for v_el in v_arr]
+                    d[k] = v_arr
                 elif 'float' in str(v_arr.dtype):
                     v_arr = [float(v_el) for v_el in v_arr]
+                    d[k] = v_arr
                 else:
-                    raise ValueError("Only int of float can be serialized")
+                    print('Skipping field: only int or float can be serialized')
             elif len(v_arr.shape) == 2:
                 if 'int' in str(v_arr.dtype):
                     v_arr = [[int(v_el) for v_el in v_row] for v_row in v_arr]
+                    d[k] = v_arr
                 elif 'float' in str(v_arr.dtype):
                     v_arr = [[float(v_el) for v_el in v_row] for v_row in v_arr]
+                    d[k] = v_arr
                 else:
-                    raise ValueError("Only int of float can be serialized")
+                    print('Skipping field: only int or float can be serialized')
             else:
-                raise ValueError("Only 1D and 2D arrays can be serialized")
-            d[k] = v_arr
+                print("Skipping field: only 1D and 2D arrays can be serialized")
     return d

--- a/spikeextractors/cacherecordingextractor.py
+++ b/spikeextractors/cacherecordingextractor.py
@@ -6,7 +6,7 @@ import os, shutil
 
 class CacheRecordingExtractor(BinDatRecordingExtractor):
 
-    extractor_name = 'CacheRecordingExtractor'
+    extractor_name = 'BinDatRecordingExtractor'
 
     def __init__(self, recording, chunk_size=None, output_folder=None):
         self._recording = recording
@@ -34,3 +34,4 @@ class CacheRecordingExtractor(BinDatRecordingExtractor):
             save_path = save_path.with_suffix('.dat')
         shutil.move(self._tmp_file, str(save_path))
         self._tmp_file = str(save_path)
+        self.kwargs['file_path'] = str(Path(self._tmp_file).absolute())

--- a/spikeextractors/cacherecordingextractor.py
+++ b/spikeextractors/cacherecordingextractor.py
@@ -40,4 +40,4 @@ class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
             save_path = save_path.with_suffix('.dat')
         shutil.move(self._tmp_file, str(save_path))
         self._tmp_file = str(save_path)
-        self.kwargs['file_path'] = str(Path(self._tmp_file).absolute())
+        self._kwargs['file_path'] = str(Path(self._tmp_file).absolute())

--- a/spikeextractors/cacherecordingextractor.py
+++ b/spikeextractors/cacherecordingextractor.py
@@ -2,13 +2,17 @@ from spikeextractors.extractors.bindatrecordingextractor import BinDatRecordingE
 from spikeextractors import RecordingExtractor
 import tempfile
 from pathlib import Path
+from copy import deepcopy
+import importlib
 import os
 import shutil
+import json
+from .baseextractor import _check_json
 
 
 class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
 
-    extractor_name = 'BinDatRecording'
+    extractor_name = 'CacheRecording'
 
     def __init__(self, recording, chunk_size=None):
         RecordingExtractor.__init__(self)  # init tmp folder before constructing BinDatRecordingExtractor
@@ -21,8 +25,11 @@ class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
                                           recording_channels=recording.get_channel_ids(),
                                           sampling_frequency=recording.get_sampling_frequency(),
                                           dtype=dtype)
+        # keep BinDatRecording kwargs
+        self._bindat_kwargs = deepcopy(self._kwargs)
         self.set_tmp_folder(tmp_folder)
         self.copy_channel_properties(recording)
+        self._kwargs = {'recording': recording, 'chunk_size': chunk_size}
 
     def __del__(self):
         try:
@@ -41,3 +48,56 @@ class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
         shutil.move(self._tmp_file, str(save_path))
         self._tmp_file = str(save_path)
         self._kwargs['file_path'] = str(Path(self._tmp_file).absolute())
+        self._bindat_kwargs['file_path'] = str(Path(self._tmp_file).absolute())
+
+    # override to make serialization avoid reloading and saving binary file
+    def make_serialized_dict(self):
+        class_name = str(BinDatRecordingExtractor).replace("<class '", "").replace("'>", '')
+        module = class_name.split('.')[0]
+        imported_module = importlib.import_module(module)
+
+        # always dumpable
+        print("Warning: dumping a CacheRecordingExtractor. The path to the tmp binary file will be lost in "
+              "further sessions. To prevent this, use the 'CacheRecordingExtractor.save_to_file('path-to-file)' "
+              "function")
+
+        dump_dict = {'class': class_name, 'module': module, 'kwargs': self._bindat_kwargs,
+                     'version': imported_module.__version__, 'dumpable': True}
+
+        if 'Recording' in class_name:
+            if 'group' in self.get_shared_channel_property_names():
+                groups = self.get_channel_groups()
+                dump_dict['groups'] = groups
+            if 'location' in self.get_shared_channel_property_names():
+                locations = self.get_channel_locations()
+                dump_dict['locations'] = locations
+        elif 'Sorting' in class_name:
+            if 'group' in self.get_shared_unit_property_names():
+                groups = [self.get_unit_property(u, 'group') for u in self.get_unit_ids()]
+                dump_dict['groups'] = groups
+
+        return dump_dict
+
+    def dump(self, folder_path=None, file_name=None):
+        '''
+        Dumps recording extractor to json file.
+        The extractor can be re-loaded with spikeextractors.load_extractor_from_json(json_file)
+
+        Parameters
+        ----------
+        folder_path: str or Path
+            Path to output_folder
+        file_name: str
+            Filename
+        '''
+        if folder_path is None:
+            folder_path = Path(os.getcwd())
+        else:
+            folder_path = Path(folder_path)
+        if file_name is None:
+            file_name = 'spikeinterface_recording.json'
+        elif Path(file_name).suffix == '':
+            file_name = file_name + '.json'
+        dump_dict = self.make_serialized_dict()
+        with open(str(folder_path / file_name), 'w', encoding='utf8') as f:
+            json.dump(_check_json(dump_dict), f, indent=4)

--- a/spikeextractors/cacherecordingextractor.py
+++ b/spikeextractors/cacherecordingextractor.py
@@ -78,17 +78,17 @@ class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
 
         return dump_dict
 
-    def dump(self, folder_path=None, file_name=None):
+    def dump(self, file_name=None, folder_path=None):
         '''
         Dumps recording extractor to json file.
         The extractor can be re-loaded with spikeextractors.load_extractor_from_json(json_file)
 
         Parameters
         ----------
-        folder_path: str or Path
-            Path to output_folder
         file_name: str
             Filename
+        folder_path: str or Path
+            Path to output_folder
         '''
         if folder_path is None:
             folder_path = Path(os.getcwd())

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -167,6 +167,8 @@ def load_probe_file(recording, probe_file, channel_map=None, channel_groups=None
     else:
         raise NotImplementedError("Only .csv and .prb probe files can be loaded.")
 
+    subrecording._kwargs['probe_file'] = str(probe_file.absolute())
+
     return subrecording
 
 
@@ -517,7 +519,6 @@ def _export_prb_file(recording, file_name, grouping_property=None, graph=True, g
 
 def _check_json(d):
     # quick hack to ensure json writable
-
     for k, v in d.items():
         if isinstance(v, Path):
             d[k] = str(v)

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -532,4 +532,4 @@ def _check_json(d):
 
 
 def load_extractor_from_json(json_file):
-    BaseExtractor.load_extractor_from_json(json_file)
+    return BaseExtractor.load_extractor_from_json(json_file)

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -3,7 +3,8 @@ import csv
 import os
 import sys
 from pathlib import Path
-
+import json
+import spikeextractors
 
 def read_python(path):
     '''Parses python scripts in a dictionary
@@ -475,3 +476,31 @@ def _export_prb_file(recording, file_name, grouping_property=None, graph=True, g
                 f.write("           'graph':  [],\n")
                 f.write('        },\n')
             f.write('}\n')
+
+
+def load_extractor_from_json(json_file):
+    '''
+    Instantiates extractor from json file
+
+    Parameters
+    ----------
+    json_file: str or Path
+        Path to json file
+
+    Returns
+    -------
+    extractor: RecordingExtractor or SortingExtractor
+        The loaded extractor object
+    '''
+    with open(str(json_file), 'r') as f:
+        d = json.load(f)
+
+    extractor = None
+    # find extractor class
+    if d['class'] in spikeextractors.recording_extractor_dict.keys():
+        reccls = spikeextractors.recording_extractor_dict[d['class']]
+        extractor = reccls(**d['kwargs'])
+    elif d['class'] in spikeextractors.sorting_extractor_dict.keys():
+        sortcls = spikeextractors.sorting_extractor_dict[d['class']]
+        extractor = sortcls(**d['kwargs'])
+    return extractor

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -532,4 +532,34 @@ def _check_json(d):
 
 
 def load_extractor_from_json(json_file):
+    '''
+    Instantiates extractor from json file
+
+    Parameters
+    ----------
+    json_file: str or Path
+        Path to json file
+
+    Returns
+    -------
+    extractor: RecordingExtractor or SortingExtractor
+        The loaded extractor object
+    '''
     return BaseExtractor.load_extractor_from_json(json_file)
+
+
+def load_extractor_from_dict(d):
+    '''
+    Instantiates extractor from dictionary
+
+    Parameters
+    ----------
+    d: dictionary
+        Python dictionary
+
+    Returns
+    -------
+    extractor: RecordingExtractor or SortingExtractor
+        The loaded extractor object
+    '''
+    return BaseExtractor.load_extractor_from_dict(d)

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -168,7 +168,6 @@ def load_probe_file(recording, probe_file, channel_map=None, channel_groups=None
         raise NotImplementedError("Only .csv and .prb probe files can be loaded.")
 
     subrecording._kwargs['probe_file'] = str(probe_file.absolute())
-
     return subrecording
 
 

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -4,7 +4,9 @@ import os
 import sys
 from pathlib import Path
 import json
+import datetime
 import spikeextractors
+
 
 def read_python(path):
     '''Parses python scripts in a dictionary
@@ -476,6 +478,22 @@ def _export_prb_file(recording, file_name, grouping_property=None, graph=True, g
                 f.write("           'graph':  [],\n")
                 f.write('        },\n')
             f.write('}\n')
+
+
+def _check_json(d):
+    # quick hack to ensure json writable
+
+    for k, v in d.items():
+        if isinstance(v, Path):
+            d[k] = str(v)
+        elif isinstance(v, (np.int, np.int32, np.int64)):
+            d[k] = int(v)
+        elif isinstance(v,  (np.float, np.float32, np.float64)):
+            d[k] = float(v)
+        elif isinstance(v, datetime.datetime):
+            d[k] = v.isoformat()
+
+    return d
 
 
 def load_extractor_from_json(json_file):

--- a/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
+++ b/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
@@ -11,6 +11,7 @@ class BinDatRecordingExtractor(RecordingExtractor):
     has_default_locations = False
     installed = True  # check at class level if installed or not
     is_writable = True
+    is_dumpable = True
     mode = 'file'      
     extractor_gui_params = [
         {'name': 'file_path', 'type': 'file', 'title': "Path to file (.dat)"},
@@ -34,6 +35,9 @@ class BinDatRecordingExtractor(RecordingExtractor):
         self._sampling_frequency = float(sampling_frequency)
         self._gain = gain
         self._geom = geom
+        self.kwargs = {'file_path': str(Path(file_path).absolute()), 'sampling_frequency': sampling_frequency,
+                       'numchan': numchan, 'dtype': str(dtype), 'recording_channels': recording_channels,
+                       'time_axis': time_axis, 'geom': geom, 'offset': offset, 'gain': gain}
 
         if recording_channels is not None:
             assert len(recording_channels) == self._timeseries.shape[0], \

--- a/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
+++ b/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
@@ -47,10 +47,10 @@ class BinDatRecordingExtractor(RecordingExtractor):
         if geom is not None:
             for idx, channel in enumerate(self._channels):
                 self.set_channel_property(channel, 'location', self._geom[idx, :])
-        self.kwargs = {'file_path': str(Path(file_path).absolute()), 'sampling_frequency': sampling_frequency,
-                       'numchan': numchan, 'dtype': str(dtype), 'recording_channels': recording_channels,
-                       'time_axis': time_axis, 'geom': geom, 'offset': offset, 'gain': gain}
-        self.append_to_dump_dict()
+        self._kwargs = {'file_path': str(Path(file_path).absolute()), 'sampling_frequency': sampling_frequency,
+                        'numchan': numchan, 'dtype': str(dtype), 'recording_channels': recording_channels,
+                        'time_axis': time_axis, 'geom': geom, 'offset': offset, 'gain': gain}
+
 
     def get_channel_ids(self):
         return self._channels

--- a/spikeextractors/extractors/biocamrecordingextractor/biocamrecordingextractor.py
+++ b/spikeextractors/extractors/biocamrecordingextractor/biocamrecordingextractor.py
@@ -4,22 +4,22 @@ import numpy as np
 from pathlib import Path
 import ctypes
 
-
 try:
     import h5py
+
     HAVE_BIOCAM = True
 except ImportError:
     HAVE_BIOCAM = False
 
-class BiocamRecordingExtractor(RecordingExtractor):
 
+class BiocamRecordingExtractor(RecordingExtractor):
     extractor_name = 'BiocamRecording'
     has_default_locations = True
     installed = HAVE_BIOCAM  # check at class level if installed or not
     is_writable = True
     is_dumpable = True
     mode = 'file'
-    extractor_gui_params = [       
+    extractor_gui_params = [
         {'name': 'file_path', 'type': 'file', 'title': "Path to file (.h5 or .hdf5)"},
         {'name': 'mea_pitch', 'type': 'int', 'value': 42, 'default': 42, 'title': "The pitch of the MEA"},
     ]
@@ -36,9 +36,8 @@ class BiocamRecordingExtractor(RecordingExtractor):
         for m in range(self._nRecCh):
             self.set_channel_property(m, 'location', self._positions[m])
 
-        self.kwargs = {'file_path': str(Path(file_path).absolute()), 'mea_pitch': mea_pitch,
-                       'verbose': verbose}
-        self.append_to_dump_dict()
+        self._kwargs = {'file_path': str(Path(file_path).absolute()), 'mea_pitch': mea_pitch,
+                        'verbose': verbose}
 
     def __del__(self):
         self._rf.close()
@@ -81,11 +80,11 @@ class BiocamRecordingExtractor(RecordingExtractor):
         N = recording.get_num_frames()
         rf = h5py.File(save_path, 'w')
         g = rf.create_group('3BData')
-        dr = rf.create_dataset('3BData/Raw', (M*N,), dtype=int)
+        dr = rf.create_dataset('3BData/Raw', (M * N,), dtype=int)
         dt = 50000
-        for i in range(N//dt):
-            dr[M*i*dt:M*(i+1)*dt] = recording.get_traces(slice(0, M), i*dt, (i+1)*dt).T.flatten()
-        dr[M*(N//dt)*dt:] = recording.get_traces(slice(0, M), (N//dt)*dt, N).T.flatten()
+        for i in range(N // dt):
+            dr[M * i * dt:M * (i + 1) * dt] = recording.get_traces(slice(0, M), i * dt, (i + 1) * dt).T.flatten()
+        dr[M * (N // dt) * dt:] = recording.get_traces(slice(0, M), (N // dt) * dt, N).T.flatten()
         g.attrs['Version'] = 101
         rf.create_dataset('3BRecInfo/3BRecVars/MinVolt', data=[0])
         rf.create_dataset('3BRecInfo/3BRecVars/MaxVolt', data=[1])
@@ -93,16 +92,16 @@ class BiocamRecordingExtractor(RecordingExtractor):
         rf.create_dataset('3BRecInfo/3BRecVars/SamplingRate', data=[recording.get_sampling_frequency()])
         rf.create_dataset('3BRecInfo/3BRecVars/SignalInversion', data=[1])
         rf.create_dataset('3BRecInfo/3BMeaChip/NCols', data=[M])
-        r = [recording.get_channel_property(i,'location')[-2] for i in range(recording.get_num_channels())]
-        c = [recording.get_channel_property(i,'location')[-1] for i in range(recording.get_num_channels())]
-        d = np.ndarray((1,len(r)),dtype=[('Row', '<i2'), ('Col', '<i2')])
+        r = [recording.get_channel_property(i, 'location')[-2] for i in range(recording.get_num_channels())]
+        c = [recording.get_channel_property(i, 'location')[-1] for i in range(recording.get_num_channels())]
+        d = np.ndarray((1, len(r)), dtype=[('Row', '<i2'), ('Col', '<i2')])
         d['Row'] = r
         d['Col'] = c
         rf.create_dataset('3BRecInfo/3BMeaStreams/Raw/Chs', data=d)
         rf.close()
 
 
-def openBiocamFile(filename,  mea_pitch, verbose=False):
+def openBiocamFile(filename, mea_pitch, verbose=False):
     """Open a Biocam hdf5 file, read and return the recording info, pick te correct method to access raw data, and return this to the caller."""
     rf = h5py.File(filename, 'r')
     # Read recording variables
@@ -132,7 +131,7 @@ def openBiocamFile(filename,  mea_pitch, verbose=False):
         print('# frames: ', nFrames)
         print('# sampling rate: ', samplingRate)
     # get channel locations
-    r = (rf['3BRecInfo/3BMeaStreams/Raw/Chs'][()]['Row'] -1) * mea_pitch
+    r = (rf['3BRecInfo/3BMeaStreams/Raw/Chs'][()]['Row'] - 1) * mea_pitch
     c = (rf['3BRecInfo/3BMeaStreams/Raw/Chs'][()]['Col'] - 1) * mea_pitch
     rawIndices = np.vstack((r, c)).T
     # assign channel numbers
@@ -141,13 +140,13 @@ def openBiocamFile(filename,  mea_pitch, verbose=False):
     if verbose:
         print("# Signal inversion is " + str(signalInv) + ".")
         print("# If your spike sorting results look wrong, invert the signal.")
-    if (file_format == 100)&(signalInv == 1):
+    if (file_format == 100) & (signalInv == 1):
         read_function = readHDF5t_100
-    elif (file_format == 100)&(signalInv == -1):
+    elif (file_format == 100) & (signalInv == -1):
         read_function = readHDF5t_100_i
-    if ((file_format == 101)|(file_format == 102))&(signalInv == 1):
+    if ((file_format == 101) | (file_format == 102)) & (signalInv == 1):
         read_function = readHDF5t_101
-    elif ((file_format == 101)|(file_format == 102))&(signalInv == -1):
+    elif ((file_format == 101) | (file_format == 102)) & (signalInv == -1):
         read_function = readHDF5t_101_i
     else:
         raise RuntimeError("File format unknown.")
@@ -161,23 +160,26 @@ def readHDF5t_100(rf, t0, t1, nch):
         raise Exception('Reading backwards? Not sure about this.')
         return rf['3BData/Raw'][t1:t0]
 
+
 def readHDF5t_100_i(rf, t0, t1, nch):
     if t0 <= t1:
-        return 4096-rf['3BData/Raw'][t0:t1]
+        return 4096 - rf['3BData/Raw'][t0:t1]
     else:  # Reversed read
         raise Exception('Reading backwards? Not sure about this.')
-        return 4096-rf['3BData/Raw'][t1:t0]
+        return 4096 - rf['3BData/Raw'][t1:t0]
+
 
 def readHDF5t_101(rf, t0, t1, nch):
     if t0 <= t1:
-        return rf['3BData/Raw'][nch * t0:nch * t1].reshape((t1-t0, nch), order='C')
+        return rf['3BData/Raw'][nch * t0:nch * t1].reshape((t1 - t0, nch), order='C')
     else:  # Reversed read
         raise Exception('Reading backwards? Not sure about this.')
-        return rf['3BData/Raw'][nch * t1:nch * t0].reshape((t1-t0, nch), order='C')
+        return rf['3BData/Raw'][nch * t1:nch * t0].reshape((t1 - t0, nch), order='C')
+
 
 def readHDF5t_101_i(rf, t0, t1, nch):
     if t0 <= t1:
-        return 4096-rf['3BData/Raw'][nch * t0:nch * t1].reshape((t1-t0, nch), order='C')
+        return 4096 - rf['3BData/Raw'][nch * t0:nch * t1].reshape((t1 - t0, nch), order='C')
     else:  # Reversed read
         raise Exception('Reading backwards? Not sure about this.')
-        return 4096-rf['3BData/Raw'][nch * t1:nch * t0].reshape((t1-t0, nch), order='C')
+        return 4096 - rf['3BData/Raw'][nch * t1:nch * t0].reshape((t1 - t0, nch), order='C')

--- a/spikeextractors/extractors/exdirextractors/exdirextractors.py
+++ b/spikeextractors/extractors/exdirextractors/exdirextractors.py
@@ -261,6 +261,8 @@ class ExdirSortingExtractor(SortingExtractor):
                             wf = waveforms[unit_idxs]
                             self.set_unit_spike_features(current_unit, 'waveforms', wf)
                         current_unit += 1
+        self._kwargs = {'folder_path': folder_path, 'sampling_frequency': sampling_frequency,
+                        'channel_group': channel_group, 'load_waveforms': load_waveforms}
 
     def get_unit_ids(self):
         return self._unit_ids

--- a/spikeextractors/extractors/exdirextractors/exdirextractors.py
+++ b/spikeextractors/extractors/exdirextractors/exdirextractors.py
@@ -261,7 +261,7 @@ class ExdirSortingExtractor(SortingExtractor):
                             wf = waveforms[unit_idxs]
                             self.set_unit_spike_features(current_unit, 'waveforms', wf)
                         current_unit += 1
-        self._kwargs = {'folder_path': folder_path, 'sampling_frequency': sampling_frequency,
+        self._kwargs = {'folder_path': str(Path(folder_path).absolute()), 'sampling_frequency': sampling_frequency,
                         'channel_group': channel_group, 'load_waveforms': load_waveforms}
 
     def get_unit_ids(self):

--- a/spikeextractors/extractors/exdirextractors/exdirextractors.py
+++ b/spikeextractors/extractors/exdirextractors/exdirextractors.py
@@ -36,9 +36,8 @@ class ExdirRecordingExtractor(RecordingExtractor):
         self._num_timepoints = self._recordings.shape[1]   
         RecordingExtractor.__init__(self)
 
-        self.kwargs = {'folder_path': str(Path(folder_path).absolute())}
-        self.append_to_dump_dict()
-        
+        self._kwargs = {'folder_path': str(Path(folder_path).absolute())}
+
     def get_channel_ids(self):
         return list(range(self._num_channels))
 

--- a/spikeextractors/extractors/hs2sortingextractor/hs2sortingextractor.py
+++ b/spikeextractors/extractors/hs2sortingextractor/hs2sortingextractor.py
@@ -1,5 +1,6 @@
 from spikeextractors import SortingExtractor
 import numpy as np
+from pathlib import Path
 
 try:
     import h5py
@@ -37,7 +38,7 @@ class HS2SortingExtractor(SortingExtractor):
         if load_unit_info:
             self.load_unit_info()
 
-        self._kwargs = {'file_path': file_path, 'load_unit_info': load_unit_info}
+        self._kwargs = {'file_path': str(Path(file_path).absolute()), 'load_unit_info': load_unit_info}
 
     def load_unit_info(self):
         if ('centres' in self._rf.keys()) and (len(self._times)>0):

--- a/spikeextractors/extractors/hs2sortingextractor/hs2sortingextractor.py
+++ b/spikeextractors/extractors/hs2sortingextractor/hs2sortingextractor.py
@@ -25,7 +25,7 @@ class HS2SortingExtractor(SortingExtractor):
         self._recording_file = file_path
         self._rf = h5py.File(self._recording_file, mode='r')
         if 'Sampling' in self._rf:
-            if(self._rf['Sampling'][()] == 0):
+            if self._rf['Sampling'][()] == 0:
                 self._sampling_frequency = None
             else:
                 self._sampling_frequency = self._rf['Sampling'][()]
@@ -34,8 +34,10 @@ class HS2SortingExtractor(SortingExtractor):
         self._unit_ids = set(self._cluster_id)
         self._times = self._rf['times'][()]
 
-        if(load_unit_info):
+        if load_unit_info:
             self.load_unit_info()
+
+        self._kwargs = {'file_path': file_path, 'load_unit_info': load_unit_info}
 
     def load_unit_info(self):
         if ('centres' in self._rf.keys()) and (len(self._times)>0):

--- a/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
+++ b/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
@@ -28,8 +28,7 @@ class IntanRecordingExtractor(RecordingExtractor):
             "Only '.rhd' and '.rhs' files are supported"
         self._recording_file = file_path
         self._recording = pyintan.File(file_path, verbose)
-        self.kwargs = {'file_path': str(Path(file_path).absolute()), 'verbose': verbose}
-        self.append_to_dump_dict()
+        self._kwargs = {'file_path': str(Path(file_path).absolute()), 'verbose': verbose}
 
     def get_channel_ids(self):
         return list(range(self._recording.analog_signals[0].signal.shape[0]))

--- a/spikeextractors/extractors/kilosortextractors/kilosortextractors.py
+++ b/spikeextractors/extractors/kilosortextractors/kilosortextractors.py
@@ -11,16 +11,15 @@ class KiloSortRecordingExtractor(PhyRecordingExtractor):
 
     mode = 'folder'
     extractor_gui_params = [
-        {'name': 'folder_path', 'type': 'folder', 'title': "str, Path to folder"},        
+        {'name': 'folder_path', 'type': 'folder', 'title': "str, Path to folder"},
     ]
     installation_mesg = ""  # error message when not installed
-    
+
     def __init__(self, folder_path):
         PhyRecordingExtractor.__init__(self, folder_path)
 
 
 class KiloSortSortingExtractor(PhySortingExtractor):
-
     extractor_name = 'KiloSortSortingExtractor'
     exporter_name = 'KiloSortSortingExporter'
     exporter_gui_params = [
@@ -44,7 +43,6 @@ class KiloSortSortingExtractor(PhySortingExtractor):
                         self._good_units.append(u)
             self._unit_ids = self._good_units
 
-        self.kwargs = {'folder_path': str(Path(folder_path).absolute()),
-                       'exclude_cluster_groups': exclude_cluster_groups, 'keep_good_only': keep_good_only,
-                       'verbose': verbose}
-        self.append_to_dump_dict()
+        self._kwargs = {'folder_path': str(Path(folder_path).absolute()),
+                        'exclude_cluster_groups': exclude_cluster_groups, 'keep_good_only': keep_good_only,
+                        'verbose': verbose}

--- a/spikeextractors/extractors/klustaextractors/klustaextractors.py
+++ b/spikeextractors/extractors/klustaextractors/klustaextractors.py
@@ -110,7 +110,7 @@ class KlustaSortingExtractor(SortingExtractor):
         for i, u in enumerate(self._unit_ids):
             self.set_unit_property(u, 'group', groups[i])
 
-        self._kwargs = {'file_or_folder_path': file_or_folder_path}
+        self._kwargs = {'file_or_folder_path': str(Path(file_or_folder_path).absolute())}
 
 
     def get_unit_ids(self):

--- a/spikeextractors/extractors/klustaextractors/klustaextractors.py
+++ b/spikeextractors/extractors/klustaextractors/klustaextractors.py
@@ -39,8 +39,7 @@ class KlustaRecordingExtractor(BinDatRecordingExtractor):
         BinDatRecordingExtractor.__init__(self, file_path=dat_file, sampling_frequency=sampling_frequency, numchan=n_channels,
                                           dtype=dtype)
 
-        self.kwargs = {'folder_path': str(Path(folder_path).absolute())}
-        self.append_to_dump_dict()
+        self._kwargs = {'folder_path': str(Path(folder_path).absolute())}
 
 
 class KlustaSortingExtractor(SortingExtractor):
@@ -53,6 +52,7 @@ class KlustaSortingExtractor(SortingExtractor):
     installation_mesg = "To use the KlustaSortingExtractor install h5py: \n\n pip install h5py\n\n"  # error message when not installed
     is_writable = True
     mode = 'file_or_folder'
+
     def __init__(self, file_or_folder_path):
         assert HAVE_KLSX, "To use the KlustaSortingExtractor install h5py: \n\n pip install h5py\n\n"
         SortingExtractor.__init__(self)

--- a/spikeextractors/extractors/klustaextractors/klustaextractors.py
+++ b/spikeextractors/extractors/klustaextractors/klustaextractors.py
@@ -110,6 +110,9 @@ class KlustaSortingExtractor(SortingExtractor):
         for i, u in enumerate(self._unit_ids):
             self.set_unit_property(u, 'group', groups[i])
 
+        self._kwargs = {'file_or_folder_path': file_or_folder_path}
+
+
     def get_unit_ids(self):
         return list(self._unit_ids)
 

--- a/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
+++ b/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
@@ -30,8 +30,7 @@ class MaxOneRecordingExtractor(RecordingExtractor):
         self._filehandle = None
         self._mapping = None
         self._initialize()
-        self.kwargs = {'file_path': str(Path(file_path).absolute()), 'verbose': verbose}
-        self.append_to_dump_dict()
+        self._kwargs = {'file_path': str(Path(file_path).absolute()), 'verbose': verbose}
 
     def _initialize(self):
         self._filehandle = h5py.File(self._file_path)

--- a/spikeextractors/extractors/mcsh5recordingextractor/mcsh5recordingextractor.py
+++ b/spikeextractors/extractors/mcsh5recordingextractor/mcsh5recordingextractor.py
@@ -30,11 +30,10 @@ class MCSH5RecordingExtractor(RecordingExtractor):
         self._verbose = verbose
         self._available_stream_ids = self.get_available_stream_ids()
         self.set_stream_id(stream_id)
-        
+
         RecordingExtractor.__init__(self)
-        self.kwargs = {'file_path': str(Path(file_path).absolute()), 'stream_id': stream_id,
-                       'verbose': verbose}
-        self.append_to_dump_dict()
+        self._kwargs = {'file_path': str(Path(file_path).absolute()), 'stream_id': stream_id,
+                        'verbose': verbose}
 
     def __del__(self):
         self._rf.close()
@@ -49,9 +48,9 @@ class MCSH5RecordingExtractor(RecordingExtractor):
         return self._samplingRate
 
     def set_stream_id(self, stream_id):
-        assert stream_id in self._available_stream_ids,  "The specified stream ID is unavailable."
+        assert stream_id in self._available_stream_ids, "The specified stream ID is unavailable."
         self._stream_id = stream_id
-        
+
         if hasattr(self, '_rf'):
             self._rf.close()
 
@@ -104,7 +103,6 @@ class MCSH5RecordingExtractor(RecordingExtractor):
                 return stream.get('ChannelData')[np.sort(channel_idxs), start_frame:end_frame] * conv
         else:
             return stream.get('ChannelData')[np.array(channel_idxs), start_frame:end_frame] * conv
-
 
     @staticmethod
     def write_recording(recording, save_path):

--- a/spikeextractors/extractors/mdaextractors/mdaextractors.py
+++ b/spikeextractors/extractors/mdaextractors/mdaextractors.py
@@ -196,7 +196,7 @@ class MdaSortingExtractor(SortingExtractor):
             inds = np.where(self._labels == unit_id)
             max_channels = self._max_channels[inds].astype(int)
             self.set_unit_property(unit_id, 'max_channel', max_channels[0])
-        self.kwargs = {'file_path': str(Path(file_path).absolute()), 'sampling_frequency': sampling_frequency}
+        self._kwargs = {'file_path': str(Path(file_path).absolute()), 'sampling_frequency': sampling_frequency}
 
     def get_unit_ids(self):
         return list(self._unit_ids)

--- a/spikeextractors/extractors/mdaextractors/mdaextractors.py
+++ b/spikeextractors/extractors/mdaextractors/mdaextractors.py
@@ -13,6 +13,7 @@ class MdaRecordingExtractor(RecordingExtractor):
     has_default_locations = True
     installed = True  # check at class level if installed or not
     is_writable = True
+    is_dumpable = True
     mode = 'folder'
     extractor_gui_params = [
         {'name': 'folder_path', 'type': 'folder', 'title': "Path to folder"},
@@ -39,6 +40,7 @@ class MdaRecordingExtractor(RecordingExtractor):
         RecordingExtractor.__init__(self)
         for m in range(self._num_channels):
             self.set_channel_property(m, 'location', self._geom[m, :])
+        self.kwargs = {'folder_path': str(Path(folder_path).absolute())}
 
     def get_channel_ids(self):
         return list(range(self._num_channels))
@@ -96,6 +98,7 @@ class MdaSortingExtractor(SortingExtractor):
     ]
     installed = True  # check at class level if installed or not
     is_writable = True
+    is_dumpable = True
     mode = 'file'
     installation_mesg = ""  # error message when not installed
 
@@ -113,6 +116,7 @@ class MdaSortingExtractor(SortingExtractor):
             inds = np.where(self._labels == unit_id)
             max_channels = self._max_channels[inds].astype(int)
             self.set_unit_property(unit_id, 'max_channel', max_channels[0])
+        self.kwargs = {'file_path': str(Path(file_path).absolute()), 'sampling_frequency': sampling_frequency}
 
     def get_unit_ids(self):
         return list(self._unit_ids)

--- a/spikeextractors/extractors/mearecextractors/mearecextractors.py
+++ b/spikeextractors/extractors/mearecextractors/mearecextractors.py
@@ -144,7 +144,7 @@ class MEArecSortingExtractor(SortingExtractor):
         self._unit_ids = None
         self._fs = None
         self._initialize()
-        self.kwargs = {'file_path': str(Path(file_path).absolute())}
+        self._kwargs = {'file_path': str(Path(file_path).absolute())}
 
     def _initialize(self):
         assert HAVE_MREX, "To use the MEArec extractors, install MEArec: \n\n pip install MEArec\n\n"

--- a/spikeextractors/extractors/mearecextractors/mearecextractors.py
+++ b/spikeextractors/extractors/mearecextractors/mearecextractors.py
@@ -42,8 +42,7 @@ class MEArecRecordingExtractor(RecordingExtractor):
             for chan, pos in enumerate(self._locations):
                 self.set_channel_property(chan, 'location', pos)
 
-        self.kwargs = {'file_path': str(Path(file_path).absolute()), 'locs_2d': locs_2d}
-        self.append_to_dump_dict()
+        self._kwargs = {'file_path': str(Path(file_path).absolute()), 'locs_2d': locs_2d}
 
     def _initialize(self):
         assert HAVE_MREX, "To use the MEArec extractors, install MEArec: \n\n pip install MEArec\n\n"

--- a/spikeextractors/extractors/mearecextractors/mearecextractors.py
+++ b/spikeextractors/extractors/mearecextractors/mearecextractors.py
@@ -12,15 +12,18 @@ try:
 except ImportError:
     HAVE_MREX = False
 
+
 class MEArecRecordingExtractor(RecordingExtractor):
 
     extractor_name = 'MEArecRecordingExtractor'
     has_default_locations = True
     installed = HAVE_MREX  # check at class level if installed or not
     is_writable = True
+    is_dumpable = True
     mode = 'file'
     extractor_gui_params = [
         {'name': 'file_path', 'type': 'file', 'title': "Path to file (.h5 or .hdf5)"},
+        {'name': 'locs_2d', 'type': 'bool', 'title': "If True 3d locations are converted to 2d"},
     ]
     installation_mesg = "To use the MEArec extractors, install MEArec: \n\n pip install MEArec\n\n"  # error message when not installed
 
@@ -34,6 +37,7 @@ class MEArecRecordingExtractor(RecordingExtractor):
         self._locations = None
         self._initialize()
         RecordingExtractor.__init__(self)
+        self.kwargs = {'file_path': str(Path(file_path).absolute()), 'locs_2d': locs_2d}
 
         if self._locations is not None:
             for chan, pos in enumerate(self._locations):
@@ -126,6 +130,7 @@ class MEArecSortingExtractor(SortingExtractor):
     ]
     installed = HAVE_MREX  # check at class level if installed or not
     is_writable = True
+    is_dumpable = True
     mode = 'file'
     installation_mesg = "To use the MEArec extractors, install MEArec: \n\n pip install MEArec\n\n"  # error message when not installed
 
@@ -137,6 +142,7 @@ class MEArecSortingExtractor(SortingExtractor):
         self._unit_ids = None
         self._fs = None
         self._initialize()
+        self.kwargs = {'file_path': str(Path(file_path).absolute())}
 
     def _initialize(self):
         assert HAVE_MREX, "To use the MEArec extractors, install MEArec: \n\n pip install MEArec\n\n"

--- a/spikeextractors/extractors/neoextractors/neobaseextractor.py
+++ b/spikeextractors/extractors/neoextractors/neobaseextractor.py
@@ -35,6 +35,8 @@ class _NeoBaseExtractor:
 
         self.block_index = block_index
         self.seg_index = seg_index
+        self._kwargs = kargs
+        self._kwargs.update({'seg_index': seg_index, 'block_index': block_index})
 
 
 class NeoBaseRecordingExtractor(RecordingExtractor, _NeoBaseExtractor):

--- a/spikeextractors/extractors/neuroscopesortingextractor/neuroscopesortingextractor.py
+++ b/spikeextractors/extractors/neuroscopesortingextractor/neuroscopesortingextractor.py
@@ -41,6 +41,8 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         else:
             self._spiketrains = []
             self._unit_ids = []
+        self._kwargs = {'resfile': resfile, 'clufile': clufile}
+
 
     def get_unit_ids(self):
         return list(self._unit_ids)

--- a/spikeextractors/extractors/neuroscopesortingextractor/neuroscopesortingextractor.py
+++ b/spikeextractors/extractors/neuroscopesortingextractor/neuroscopesortingextractor.py
@@ -1,5 +1,7 @@
 from spikeextractors import SortingExtractor
 import numpy as np
+from pathlib import Path
+
 
 class NeuroscopeSortingExtractor(SortingExtractor):
 
@@ -41,7 +43,8 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         else:
             self._spiketrains = []
             self._unit_ids = []
-        self._kwargs = {'resfile': resfile, 'clufile': clufile}
+        self._kwargs = {'resfile': str(Path(resfile).absolute()),
+                        'clufile': str(Path(clufile).absolute())}
 
 
     def get_unit_ids(self):

--- a/spikeextractors/extractors/nixioextractors/nixioextractors.py
+++ b/spikeextractors/extractors/nixioextractors/nixioextractors.py
@@ -168,7 +168,7 @@ class NIXIOSortingExtractor(SortingExtractor):
             sfreq = md["sampling_frequency"]
             self._sampling_frequency = sfreq
         self._load_properties()
-        self._kwargs = {'file_path': file_path}
+        self._kwargs = {'file_path': str(Path(file_path).absolute())}
 
     def __del__(self):
         self._file.close()

--- a/spikeextractors/extractors/nixioextractors/nixioextractors.py
+++ b/spikeextractors/extractors/nixioextractors/nixioextractors.py
@@ -168,6 +168,7 @@ class NIXIOSortingExtractor(SortingExtractor):
             sfreq = md["sampling_frequency"]
             self._sampling_frequency = sfreq
         self._load_properties()
+        self._kwargs = {'file_path': file_path}
 
     def __del__(self):
         self._file.close()

--- a/spikeextractors/extractors/nixioextractors/nixioextractors.py
+++ b/spikeextractors/extractors/nixioextractors/nixioextractors.py
@@ -35,8 +35,7 @@ class NIXIORecordingExtractor(RecordingExtractor):
         RecordingExtractor.__init__(self)
         self._file = nix.File.open(file_path, nix.FileMode.ReadOnly)
         self._load_properties()
-        self.kwargs = {'file_path': str(Path(file_path).absolute())}
-        self.append_to_dump_dict()
+        self._kwargs = {'file_path': str(Path(file_path).absolute())}
 
     def __del__(self):
         self._file.close()

--- a/spikeextractors/extractors/npzsortingextractor/npzsortingextractor.py
+++ b/spikeextractors/extractors/npzsortingextractor/npzsortingextractor.py
@@ -38,6 +38,7 @@ class NpzSortingExtractor(SortingExtractor):
             self._sampling_frequency = float(npz['sampling_frequency'][0])
         else:
             self._sampling_frequency = None
+        self._kwargs = {'file_path': file_path}
 
     def get_unit_ids(self):
         return list(self.unit_ids)

--- a/spikeextractors/extractors/npzsortingextractor/npzsortingextractor.py
+++ b/spikeextractors/extractors/npzsortingextractor/npzsortingextractor.py
@@ -38,7 +38,7 @@ class NpzSortingExtractor(SortingExtractor):
             self._sampling_frequency = float(npz['sampling_frequency'][0])
         else:
             self._sampling_frequency = None
-        self._kwargs = {'file_path': file_path}
+        self._kwargs = {'file_path': str(Path(file_path).absolute())}
 
     def get_unit_ids(self):
         return list(self.unit_ids)

--- a/spikeextractors/extractors/numpyextractors/numpyextractors.py
+++ b/spikeextractors/extractors/numpyextractors/numpyextractors.py
@@ -12,6 +12,7 @@ like any other Recording/SortingExtractor.
 class NumpyRecordingExtractor(RecordingExtractor):
     extractor_name = 'NumpyRecordingExtractor'
     is_writable = True
+    is_dumpable = False
     def __init__(self, timeseries, sampling_frequency, geom=None):
         if isinstance(timeseries, str):
             if Path(timeseries).is_file():
@@ -55,6 +56,8 @@ class NumpyRecordingExtractor(RecordingExtractor):
 class NumpySortingExtractor(SortingExtractor):
     extractor_name = 'NumpySortingExtractor'
     is_writable = False
+    is_dumpable = False
+
     def __init__(self):
         SortingExtractor.__init__(self)
         self._units = {}

--- a/spikeextractors/extractors/numpyextractors/numpyextractors.py
+++ b/spikeextractors/extractors/numpyextractors/numpyextractors.py
@@ -17,6 +17,7 @@ class NumpyRecordingExtractor(RecordingExtractor):
     def __init__(self, timeseries, sampling_frequency, geom=None):
         if isinstance(timeseries, str):
             if Path(timeseries).is_file():
+                self.is_dumpable = True
                 self._timeseries = np.load(timeseries)
         elif isinstance(timeseries, np.ndarray):
             self._timeseries = timeseries

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -462,7 +462,7 @@ class NwbSortingExtractor(se.SortingExtractor):
     mode = 'file'
     installation_mesg = "To use the Nwb extractors, install pynwb: \n\n pip install pynwb\n\n"
 
-    def __init__(self, path, electrical_series=None, sampling_frequency=None):
+    def __init__(self, file_path, electrical_series=None, sampling_frequency=None):
         """
 
         Parameters
@@ -472,7 +472,7 @@ class NwbSortingExtractor(se.SortingExtractor):
         """
         check_nwb_install()
         se.SortingExtractor.__init__(self)
-        self._path = path
+        self._path = file_path
         with NWBHDF5IO(self._path, 'r') as io:
             nwbfile = io.read()
             if sampling_frequency is None:
@@ -521,6 +521,9 @@ class NwbSortingExtractor(se.SortingExtractor):
                     'start_frame': self.time_to_frame(row['start_time']),
                     'end_frame': self.time_to_frame(row['stop_time'])}
                     for _, row in df_epochs.iterrows()}
+        self._kwargs = {'file_path': str(Path(file_path).absolute()), 'electrical_series': electrical_series,
+                        'sampling_frequency': sampling_frequency}
+
 
 
     def get_unit_ids(self):

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -209,8 +209,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                     'start_frame': self.time_to_frame(row['start_time']),
                     'end_frame': self.time_to_frame(row['stop_time'])}
                     for _, row in df_epochs.iterrows()}
-        self.kwargs = {'file_path': str(Path(file_path).absolute()), 'electrical_series_name': electrical_series_name}
-        self.append_to_dump_dict()
+        self._kwargs = {'file_path': str(Path(file_path).absolute()), 'electrical_series_name': electrical_series_name}
 
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         check_nwb_install()

--- a/spikeextractors/extractors/openephysextractors/openephysextractors.py
+++ b/spikeextractors/extractors/openephysextractors/openephysextractors.py
@@ -67,14 +67,17 @@ class OpenEphysSortingExtractor(SortingExtractor):
     mode = 'file'
     installation_mesg = "To use the OpenEphys extractor, install pyopenephys: \n\n pip install pyopenephys\n\n"  # error message when not installed
 
-    def __init__(self, file_path, *, experiment_id=0, recording_id=0):
+    def __init__(self, folder_path, *, experiment_id=0, recording_id=0):
         assert HAVE_OE, "To use the OpenEphys extractor, install pyopenephys: \n\n pip install pyopenephys\n\n"
         SortingExtractor.__init__(self)
-        self._recording_file = file_path
-        self._recording = pyopenephys.File(file_path).experiments[experiment_id].recordings[recording_id]
+        self._recording_file = folder_path
+        self._recording = pyopenephys.File(folder_path).experiments[experiment_id].recordings[recording_id]
         self._spiketrains = self._recording.spiketrains
         self._unit_ids = list([np.unique(st.clusters)[0] for st in self._spiketrains])
         self._sampling_frequency = float(self._recording.sample_rate.rescale('Hz').magnitude)
+
+        self._kwargs = {'folder_path': str(Path(folder_path).absolute()), 'experiment_id': experiment_id,
+                        'recording_id': recording_id}
 
     def get_unit_ids(self):
         return self._unit_ids

--- a/spikeextractors/extractors/openephysextractors/openephysextractors.py
+++ b/spikeextractors/extractors/openephysextractors/openephysextractors.py
@@ -2,16 +2,15 @@ from spikeextractors import RecordingExtractor, SortingExtractor
 from pathlib import Path
 import numpy as np
 
-
 try:
     import pyopenephys
+
     HAVE_OE = True
 except ImportError:
     HAVE_OE = False
 
 
 class OpenEphysRecordingExtractor(RecordingExtractor):
-
     extractor_name = 'OpenEphysRecording'
     has_default_locations = False
     installed = HAVE_OE  # check at class level if installed or not
@@ -20,9 +19,9 @@ class OpenEphysRecordingExtractor(RecordingExtractor):
     mode = 'folder'
     extractor_gui_params = [
         {'name': 'folder_path', 'type': 'folder', 'title': "str, Path to folder_path"},
-        {'name': 'experiment_id', 'type': 'int', 'value':0, 'default':0, 'title': "Experiment ID"},
-        {'name': 'recording_id', 'type': 'int', 'value':0, 'default':0, 'title': "Recording ID"},
-        {'name': 'dtype', 'type': 'str',  'value':'float', 'default':'float', 'title':"dtype ('float' or 'int')"},
+        {'name': 'experiment_id', 'type': 'int', 'value': 0, 'default': 0, 'title': "Experiment ID"},
+        {'name': 'recording_id', 'type': 'int', 'value': 0, 'default': 0, 'title': "Recording ID"},
+        {'name': 'dtype', 'type': 'str', 'value': 'float', 'default': 'float', 'title': "dtype ('float' or 'int')"},
     ]
 
     installation_mesg = "To use the OpenEphys extractor, install pyopenephys: \n\n pip install pyopenephys\n\n"  # error message when not installed
@@ -34,9 +33,8 @@ class OpenEphysRecordingExtractor(RecordingExtractor):
         self._recording_file = folder_path
         self._recording = pyopenephys.File(folder_path).experiments[experiment_id].recordings[recording_id]
         self._dtype = dtype
-        self.kwargs = {'folder_path': str(Path(folder_path).absolute()), 'experiment_id': experiment_id,
-                       'recording_id': recording_id, 'dtype': dtype}
-        self.append_to_dump_dict()
+        self._kwargs = {'folder_path': str(Path(folder_path).absolute()), 'experiment_id': experiment_id,
+                        'recording_id': recording_id, 'dtype': dtype}
 
     def get_channel_ids(self):
         return list(range(self._recording.analog_signals[0].signal.shape[0]))
@@ -63,7 +61,6 @@ class OpenEphysRecordingExtractor(RecordingExtractor):
 
 
 class OpenEphysSortingExtractor(SortingExtractor):
-
     extractor_name = 'OpenEphysSortingExtractor'
     installed = HAVE_OE  # check at class level if installed or not
     is_writable = False

--- a/spikeextractors/extractors/phyextractors/phyextractors.py
+++ b/spikeextractors/extractors/phyextractors/phyextractors.py
@@ -201,6 +201,8 @@ class PhySortingExtractor(SortingExtractor):
                     wf = recording.get_snippets(reference_frames=spiketrain,
                                                 snippet_len=[int(frames_before), int(frames_after)])
                     self.set_unit_spike_features(u, 'waveforms', wf)
+        self._kwargs = {'folder_path': folder_path, 'exclude_cluster_groups': exclude_cluster_groups,
+                        'load_waveforms': load_waveforms, 'verbose': verbose}
 
     def get_unit_ids(self):
         return list(self._unit_ids)

--- a/spikeextractors/extractors/phyextractors/phyextractors.py
+++ b/spikeextractors/extractors/phyextractors/phyextractors.py
@@ -51,8 +51,7 @@ class PhyRecordingExtractor(BinDatRecordingExtractor):
             for (ch, loc) in zip(self.get_channel_ids(), channel_locations):
                 self.set_channel_property(ch, 'location', loc)
 
-        self.kwargs = {'folder_path': str(Path(folder_path).absolute())}
-        self.append_to_dump_dict()
+        self._kwargs = {'folder_path': str(Path(folder_path).absolute())}
 
 
 class PhySortingExtractor(SortingExtractor):

--- a/spikeextractors/extractors/phyextractors/phyextractors.py
+++ b/spikeextractors/extractors/phyextractors/phyextractors.py
@@ -201,7 +201,8 @@ class PhySortingExtractor(SortingExtractor):
                     wf = recording.get_snippets(reference_frames=spiketrain,
                                                 snippet_len=[int(frames_before), int(frames_after)])
                     self.set_unit_spike_features(u, 'waveforms', wf)
-        self._kwargs = {'folder_path': folder_path, 'exclude_cluster_groups': exclude_cluster_groups,
+        self._kwargs = {'folder_path': str(Path(folder_path).absolute()),
+                        'exclude_cluster_groups': exclude_cluster_groups,
                         'load_waveforms': load_waveforms, 'verbose': verbose}
 
     def get_unit_ids(self):

--- a/spikeextractors/extractors/shybridextractors/shybridextractors.py
+++ b/spikeextractors/extractors/shybridextractors/shybridextractors.py
@@ -50,8 +50,7 @@ class SHYBRIDRecordingExtractor(BinDatRecordingExtractor):
                                           time_axis=time_axis)
 
         self = load_probe_file(self, params['probe'])
-        self.kwargs = {'file_path': str(Path(file_path).absolute())}
-        self.append_to_dump_dict()
+        self._kwargs = {'file_path': str(Path(file_path).absolute())}
 
     @staticmethod
     def write_recording(recording, save_path, initial_sorting_fn, dtype='float32'):

--- a/spikeextractors/extractors/shybridextractors/shybridextractors.py
+++ b/spikeextractors/extractors/shybridextractors/shybridextractors.py
@@ -119,7 +119,7 @@ class SHYBRIDSortingExtractor(SortingExtractor):
             self._spike_clusters.fromCSV(file_path, None, delimiter=delimiter)
         else:
             raise FileNotFoundError('the ground truth file "{}" could not be found'.format(file_path))
-        self._kwargs = {'file_path': file_path, 'delimiter': delimiter}
+        self._kwargs = {'file_path': str(Path(file_path).absolute()), 'delimiter': delimiter}
 
     def get_unit_ids(self):
         return self._spike_clusters.keys()

--- a/spikeextractors/extractors/shybridextractors/shybridextractors.py
+++ b/spikeextractors/extractors/shybridextractors/shybridextractors.py
@@ -119,6 +119,7 @@ class SHYBRIDSortingExtractor(SortingExtractor):
             self._spike_clusters.fromCSV(file_path, None, delimiter=delimiter)
         else:
             raise FileNotFoundError('the ground truth file "{}" could not be found'.format(file_path))
+        self._kwargs = {'file_path': file_path, 'delimiter': delimiter}
 
     def get_unit_ids(self):
         return self._spike_clusters.keys()

--- a/spikeextractors/extractors/shybridextractors/shybridextractors.py
+++ b/spikeextractors/extractors/shybridextractors/shybridextractors.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     HAVE_SBEX = False
 
+
 class SHYBRIDRecordingExtractor(BinDatRecordingExtractor):
     extractor_name = 'SHYBRIDRecording'
     installed = HAVE_SBEX
@@ -48,9 +49,9 @@ class SHYBRIDRecordingExtractor(BinDatRecordingExtractor):
                                           nb_channels,
                                           params['dtype'],
                                           time_axis=time_axis)
-
-        self = load_probe_file(self, params['probe'])
         self._kwargs = {'file_path': str(Path(file_path).absolute())}
+        self = load_probe_file(self, params['probe'])
+
 
     @staticmethod
     def write_recording(recording, save_path, initial_sorting_fn, dtype='float32'):

--- a/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
@@ -65,9 +65,7 @@ class SpikeGLXRecordingExtractor(RecordingExtractor):
 
         # set gains - convert from int16 to uVolt
         self.set_channel_gains(self._channels, gains*1e6)
-        self.kwargs = {'file_path': str(Path(file_path).absolute()), 'x_pitch': x_pitch,
-                       'y_pitch': y_pitch}
-        self.append_to_dump_dict()
+        self._kwargs = {'file_path': str(Path(file_path).absolute()), 'x_pitch': x_pitch, 'y_pitch': y_pitch}
 
 
     def get_channel_ids(self):

--- a/spikeextractors/extractors/spykingcircusextractors/spykingcircusextractors.py
+++ b/spikeextractors/extractors/spykingcircusextractors/spykingcircusextractors.py
@@ -119,6 +119,8 @@ class SpykingCircusSortingExtractor(SortingExtractor):
             self._spiketrains.append(np.array(f_results['spiketimes'][temp]).astype('int64'))
             self._unit_ids.append(int(temp.split('_')[-1]))
 
+        self._kwargs = {'folder_path': folder_path}
+
     def get_unit_ids(self):
         return list(self._unit_ids)
 

--- a/spikeextractors/extractors/spykingcircusextractors/spykingcircusextractors.py
+++ b/spikeextractors/extractors/spykingcircusextractors/spykingcircusextractors.py
@@ -119,7 +119,7 @@ class SpykingCircusSortingExtractor(SortingExtractor):
             self._spiketrains.append(np.array(f_results['spiketimes'][temp]).astype('int64'))
             self._unit_ids.append(int(temp.split('_')[-1]))
 
-        self._kwargs = {'folder_path': folder_path}
+        self._kwargs = {'folder_path': str(Path(folder_path).absolute())}
 
     def get_unit_ids(self):
         return list(self._unit_ids)

--- a/spikeextractors/extractors/spykingcircusextractors/spykingcircusextractors.py
+++ b/spikeextractors/extractors/spykingcircusextractors/spykingcircusextractors.py
@@ -52,8 +52,7 @@ class SpykingCircusRecordingExtractor(NumpyRecordingExtractor):
             if f.suffix == '.npy':
                 recording_file = str(f)
         NumpyRecordingExtractor.__init__(self, recording_file, sample_rate)
-        self.kwargs = {'folder_path': str(Path(folder_path).absolute())}
-        self.append_to_dump_dict()
+        self._kwargs = {'folder_path': str(Path(folder_path).absolute())}
 
 
 class SpykingCircusSortingExtractor(SortingExtractor):

--- a/spikeextractors/extractors/tridescloussortingextractor/tridescloussortingextractor.py
+++ b/spikeextractors/extractors/tridescloussortingextractor/tridescloussortingextractor.py
@@ -31,7 +31,7 @@ class TridesclousSortingExtractor(SortingExtractor):
         self.catalogue = self.dataio.load_catalogue(name='initial', chan_grp=chan_grp)
         
         self._sampling_frequency = self.dataio.sample_rate
-        self._kwargs = {'folder_path': folder_path, 'chan_grp': chan_grp}
+        self._kwargs = {'folder_path': str(Path(folder_path).absolute()), 'chan_grp': chan_grp}
 
     def get_unit_ids(self):
         labels = self.catalogue['clusters']['cluster_label']

--- a/spikeextractors/extractors/tridescloussortingextractor/tridescloussortingextractor.py
+++ b/spikeextractors/extractors/tridescloussortingextractor/tridescloussortingextractor.py
@@ -31,6 +31,7 @@ class TridesclousSortingExtractor(SortingExtractor):
         self.catalogue = self.dataio.load_catalogue(name='initial', chan_grp=chan_grp)
         
         self._sampling_frequency = self.dataio.sample_rate
+        self._kwargs = {'folder_path': folder_path, 'chan_grp': chan_grp}
 
     def get_unit_ids(self):
         labels = self.catalogue['clusters']['cluster_label']

--- a/spikeextractors/multirecordingchannelextractor.py
+++ b/spikeextractors/multirecordingchannelextractor.py
@@ -38,7 +38,7 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
                 for i, group in enumerate(groups):
                     recording = recordings[i]                    
                     channel_ids = recording.get_channel_ids()
-                    recording.set_channel_groups(channel_ids, groups=np.repeat(group,len(channel_ids)))
+                    recording.set_channel_groups(channel_ids=channel_ids, groups=np.repeat(group,len(channel_ids)))
             else:
                 raise ValueError("recordings and groups must have same length")
 

--- a/spikeextractors/multirecordingchannelextractor.py
+++ b/spikeextractors/multirecordingchannelextractor.py
@@ -41,6 +41,7 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
                     recording.set_channel_groups(channel_ids=channel_ids, groups=np.repeat(group,len(channel_ids)))
             else:
                 raise ValueError("recordings and groups must have same length")
+        self._kwargs = {'recordings': [rec.make_serialized_dict() for rec in recordings], 'groups': groups}
 
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)

--- a/spikeextractors/multirecordingtimeextractor.py
+++ b/spikeextractors/multirecordingtimeextractor.py
@@ -50,6 +50,7 @@ class MultiRecordingTimeExtractor(RecordingExtractor):
 
         # Set the channel properties based on the first recording extractor
         self.copy_channel_properties(self._first_recording)
+        self._kwargs = {'recordings': [rec.make_serialized_dict() for rec in recordings], 'epoch_names': epoch_names}
 
     def _find_section_for_frame(self, frame):
         inds = np.where(np.array(self._start_frames[:-1]) <= frame)[0]

--- a/spikeextractors/multisortingextractor.py
+++ b/spikeextractors/multisortingextractor.py
@@ -21,6 +21,7 @@ class MultiSortingExtractor(SortingExtractor):
                 self._all_unit_ids.append(u_id)
                 self._unit_map[u_id] = {'sorting_id': s_i, 'unit_id': unit_id}
                 u_id += 1
+        self._kwargs = {'sortings': [sort.make_serialized_dict() for sort in sortings]}
 
     def get_unit_ids(self):
         return list(self._all_unit_ids)

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -19,7 +19,6 @@ class RecordingExtractor(ABC, BaseExtractor):
         BaseExtractor.__init__(self)
         self._epochs = {}
         self._channel_properties = {}
-        self._tmp_folder = None
         self.id = random.randint(a=0, b=9223372036854775807)
 
     def __del__(self):
@@ -251,19 +250,21 @@ class RecordingExtractor(ABC, BaseExtractor):
         for channel_id in channel_ids:
             location = self.get_channel_property(channel_id, 'location')
             locations.append(location)
-        return locations
+        return np.array(locations)
 
-    def set_channel_groups(self, channel_ids, groups):
+    def set_channel_groups(self, groups, channel_ids=None):
         '''This function sets the group property of each specified channel
         id with the corresponding group of the passed in groups list.
 
         Parameters
         ----------
-        channel_ids: array_like
-            The channel ids (ints) for which the groups will be specified
         groups: array_like
-            A list of corresonding groups (ints) for the given channel_ids
+            A list of groups (ints) for the channel_ids
+        channel_ids: array_like or None
+            The channel ids (ints) for which the groups will be specified. If None, all channel ids are assumed
         '''
+        if channel_ids is None:
+            channel_ids = self.get_channel_ids()
         if len(channel_ids) == len(groups):
             for i in range(len(channel_ids)):
                 if isinstance(groups[i], (int, np.integer)):

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -1,8 +1,11 @@
 from abc import ABC, abstractmethod
 import numpy as np
-import copy
+import json
+import os
+from pathlib import Path
 import random
-from .extraction_tools import load_probe_file, save_to_probe_file, write_to_binary_dat_format, get_sub_extractors_by_property
+from .extraction_tools import load_probe_file, save_to_probe_file, write_to_binary_dat_format, \
+    get_sub_extractors_by_property
 
 class RecordingExtractor(ABC):
     '''A class that contains functions for extracting important information
@@ -15,6 +18,7 @@ class RecordingExtractor(ABC):
     def __init__(self):
         self._epochs = {}
         self._channel_properties = {}
+        self.kwargs = {}
         self.id = random.randint(a=0, b=9223372036854775807)
 
     @abstractmethod
@@ -713,3 +717,23 @@ class RecordingExtractor(ABC):
         '''
         raise NotImplementedError("The write_recording function is not \
                                   implemented for this extractor")
+
+    def dump(self, output_folder=None):
+        '''
+        Dumps recording extractor to json file.
+        The extractor can be re-loaded with spikeextractors.load_extractor_from_json(json_file)
+
+        Parameters
+        ----------
+        output_folder: str or Path
+            Path to output_folder
+        '''
+        if self.is_dumpable:
+            class_type = self.extractor_name
+            d = {'class': class_type, 'kwargs': self.kwargs}
+            if output_folder is None:
+                output_folder = Path(os.getcwd())
+            with open(str(output_folder / 'spikeinterface_recording.json'), 'w', encoding='utf8') as f:
+                json.dump(d, f, indent=4)
+        else:
+            raise ValueError("The recording extractor cannot be dumped to json.")

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -1,8 +1,5 @@
 from abc import ABC, abstractmethod
 import numpy as np
-import json
-import os
-import string
 import tempfile
 import shutil
 import random

--- a/spikeextractors/sortingextractor.py
+++ b/spikeextractors/sortingextractor.py
@@ -22,7 +22,6 @@ class SortingExtractor(ABC, BaseExtractor):
         self._epochs = {}
         self._unit_properties = {}
         self._unit_features = {}
-        self._tmp_folder = None
         self._sampling_frequency = None
         self.id = np.random.randint(low=0, high=9223372036854775807, dtype='int64')
 

--- a/spikeextractors/sortingextractor.py
+++ b/spikeextractors/sortingextractor.py
@@ -2,16 +2,14 @@ from abc import ABC, abstractmethod
 import numpy as np
 import json
 import os
-import copy
-import random
-import string
 import tempfile
 from pathlib import Path
 import shutil
 from .extraction_tools import get_sub_extractors_by_property
+from .baseextractor import BaseExtractor
 
 
-class SortingExtractor(ABC):
+class SortingExtractor(ABC, BaseExtractor):
     '''A class that contains functions for extracting important information
     from spiked sorted data given a spike sorting software. It is an abstract
     class so all functions with the @abstractmethod tag must be implemented for
@@ -20,6 +18,7 @@ class SortingExtractor(ABC):
 
     '''
     def __init__(self):
+        BaseExtractor.__init__(self)
         self._epochs = {}
         self._unit_properties = {}
         self._unit_features = {}
@@ -727,54 +726,6 @@ class SortingExtractor(ABC):
         '''
         raise NotImplementedError("The write_sorting function is not \
                                   implemented for this extractor")
-
-    def append_to_dump_dict(self):
-        try:
-            self._dump_dict
-        except:
-            self._dump_dict = {}
-        keys = self._dump_dict.keys()
-
-        if len(keys) == 0:
-            current_key = 0
-        else:
-            current_key = max(keys) + 1
-
-        # extractors
-        try:
-            self._dump_dict[current_key] = {'name': self.extractor_name, 'type': 'extractor',
-                                            'kwargs': self.kwargs}
-        except:
-            pass
-        # curators
-        try:
-            self._dump_dict[current_key] = {'name': self.curator_name, 'type': 'curator',
-                                            'kwargs': self.kwargs}
-        except:
-            pass
-
-    def dump(self, output_folder=None, output_filename=None):
-        '''
-        Dumps recording extractor to json file.
-        The extractor can be re-loaded with spikeextractors.load_extractor_from_json(json_file)
-
-        Parameters
-        ----------
-        output_folder: str or Path
-            Path to output_folder
-        output_filename: str
-            Filename
-        '''
-        if output_folder is None:
-            output_folder = Path(os.getcwd())
-        else:
-            output_folder = Path(output_folder)
-        if output_filename is None:
-            output_filename = 'spikeinterface_recording.json'
-        elif Path(output_filename).suffix == '':
-            output_filename = output_filename + '.json'
-        with open(str(output_folder / output_filename), 'w', encoding='utf8') as f:
-            json.dump(self._dump_dict, f, indent=4)
 
     def _cast_start_end_frame(self, start_frame, end_frame):
         if isinstance(start_frame, (float, np.float)):

--- a/spikeextractors/sortingextractor.py
+++ b/spikeextractors/sortingextractor.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
 import numpy as np
-import copy
+import json
+import os
+from pathlib import Path
 from .extraction_tools import get_sub_extractors_by_property
-
 
 
 class SortingExtractor(ABC):
@@ -635,3 +636,23 @@ class SortingExtractor(ABC):
         '''
         raise NotImplementedError("The write_sorting function is not \
                                   implemented for this extractor")
+
+    def dump(self, output_folder=None):
+        '''
+        Dumps sorting extractor to json file.
+        The extractor can be re-loaded with spikeextractors.load_extractor_from_json(json_file)
+
+        Parameters
+        ----------
+        output_folder: str or Path
+            Path to output_folder
+        '''
+        if self.is_dumpable:
+            class_type = self.extractor_name
+            d = {'class': class_type, 'kwargs': self.kwargs}
+            if output_folder is None:
+                output_folder = Path(os.getcwd())
+            with open(str(output_folder / 'spikeinterface_sorting.json'), 'w', encoding='utf8') as f:
+                json.dump(d, f, indent=4)
+        else:
+            raise ValueError("The recording extractor cannot be dumped to json.")

--- a/spikeextractors/subrecordingextractor.py
+++ b/spikeextractors/subrecordingextractor.py
@@ -30,11 +30,8 @@ class SubRecordingExtractor(RecordingExtractor):
         self.copy_channel_properties(parent_recording, channel_ids=self._renamed_channel_ids)
 
         # update dump dict
-        self._dump_dict = parent_recording._dump_dict
-        self.kwargs = {'channel_ids': channel_ids, 'renamed_channel_ids': renamed_channel_ids,
-                       'start_frame': start_frame, 'end_frame': end_frame}
-        self.append_to_dump_dict()
-
+        self._kwargs = {'parent_recording': parent_recording.make_serialized_dict(), 'channel_ids': channel_ids,
+                        'renamed_channel_ids': renamed_channel_ids, 'start_frame': start_frame, 'end_frame': end_frame}
 
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)

--- a/spikeextractors/subsortingextractor.py
+++ b/spikeextractors/subsortingextractor.py
@@ -29,6 +29,8 @@ class SubSortingExtractor(SortingExtractor):
         self.copy_unit_properties(parent_sorting, unit_ids=self._renamed_unit_ids)
         self.copy_unit_spike_features(parent_sorting, unit_ids=self._renamed_unit_ids, start_frame=start_frame,
                                       end_frame=end_frame)
+        self._kwargs = {'parent_sorting': parent_sorting.make_serialized_dict(), 'unit_ids': unit_ids,
+                        'renamed_unit_ids': renamed_unit_ids, 'start_frame': start_frame, 'end_frame': end_frame}
 
     def get_unit_ids(self):
         return list(self._renamed_unit_ids)

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -54,9 +54,9 @@ class TestExtractors(unittest.TestCase):
             RX.set_channel_property(channel_id=channel_id, property_name='shared_channel_prop', value=i)
 
         SX3 = se.NumpySortingExtractor()
-        train3= np.asarray([1,20,21,35,38,45,46,47])
+        train3 = np.asarray([1, 20, 21, 35, 38, 45, 46, 47])
         SX3.add_unit(unit_id=0, times=train3)
-        features3 = np.asarray([0,5,10,15,20,25,30,35])
+        features3 = np.asarray([0, 5, 10, 15, 20, 25, 30, 35])
         SX3.set_unit_spike_features(unit_id=0, feature_name='dummy', value=features3)
 
         example_info = dict(
@@ -96,15 +96,20 @@ class TestExtractors(unittest.TestCase):
 
         print(self.SX3.get_unit_spike_features(0, 'dummy'))
         self.assertTrue(np.array_equal(self.SX3.get_unit_spike_features(0, 'dummy'), self.example_info['features3']))
-        self.assertTrue(np.array_equal(self.SX3.get_unit_spike_features(0, 'dummy', start_frame=4), self.example_info['features3'][1:]))
-        self.assertTrue(np.array_equal(self.SX3.get_unit_spike_features(0, 'dummy', end_frame=4), self.example_info['features3'][:1]))
-        self.assertTrue(np.array_equal(self.SX3.get_unit_spike_features(0, 'dummy', start_frame=20, end_frame=46), self.example_info['features3'][1:6]))
+        self.assertTrue(np.array_equal(self.SX3.get_unit_spike_features(0, 'dummy', start_frame=4),
+                                       self.example_info['features3'][1:]))
+        self.assertTrue(np.array_equal(self.SX3.get_unit_spike_features(0, 'dummy', end_frame=4),
+                                       self.example_info['features3'][:1]))
+        self.assertTrue(np.array_equal(self.SX3.get_unit_spike_features(0, 'dummy', start_frame=20, end_frame=46),
+                                       self.example_info['features3'][1:6]))
 
         sub_extractor_full = se.SubSortingExtractor(self.SX3)
         sub_extractor_partial = se.SubSortingExtractor(self.SX3, start_frame=20, end_frame=46)
 
-        self.assertTrue(np.array_equal(sub_extractor_full.get_unit_spike_features(0, 'dummy'), self.SX3.get_unit_spike_features(0, 'dummy')))
-        self.assertTrue(np.array_equal(sub_extractor_partial.get_unit_spike_features(0, 'dummy'), self.SX3.get_unit_spike_features(0, 'dummy', start_frame=20, end_frame=46)))
+        self.assertTrue(np.array_equal(sub_extractor_full.get_unit_spike_features(0, 'dummy'),
+                                       self.SX3.get_unit_spike_features(0, 'dummy')))
+        self.assertTrue(np.array_equal(sub_extractor_partial.get_unit_spike_features(0, 'dummy'),
+                                       self.SX3.get_unit_spike_features(0, 'dummy', start_frame=20, end_frame=46)))
 
         self._check_recording_return_types(self.RX)
 
@@ -139,6 +144,7 @@ class TestExtractors(unittest.TestCase):
         cache_extractor.save_to_file('cache')
 
         assert cache_extractor.filename == 'cache.dat'
+        self._check_dumping(cache_extractor)
         del cache_extractor
         assert not Path('cache.dat').is_file()
 
@@ -153,6 +159,8 @@ class TestExtractors(unittest.TestCase):
         self._check_recordings_equal(self.RX, RX_mda)
         self._check_sorting_return_types(SX_mda)
         self._check_sortings_equal(self.SX, SX_mda)
+        self._check_dumping(RX_mda)
+        self._check_dumping(SX_mda)
 
     def _check_recording_return_types(self, RX):
         channel_ids = RX.get_channel_ids()
@@ -172,6 +180,7 @@ class TestExtractors(unittest.TestCase):
         RX_biocam = se.BiocamRecordingExtractor(path1)
         self._check_recording_return_types(RX_biocam)
         self._check_recordings_equal(self.RX, RX_biocam)
+        self._check_dumping(RX_biocam)
 
     def test_mearec_extractors(self):
         path1 = self.test_dir + '/raw.h5'
@@ -180,12 +189,14 @@ class TestExtractors(unittest.TestCase):
         tr = RX_mearec.get_traces(channel_ids=[0, 1], end_frame=1000)
         self._check_recording_return_types(RX_mearec)
         self._check_recordings_equal(self.RX, RX_mearec)
+        self._check_dumping(RX_mearec)
 
         path2 = self.test_dir + '/firings_true.h5'
         se.MEArecSortingExtractor.write_sorting(self.SX, path2, self.RX.get_sampling_frequency())
         SX_mearec = se.MEArecSortingExtractor(path2)
         self._check_sorting_return_types(SX_mearec)
         self._check_sortings_equal(self.SX, SX_mearec)
+        self._check_dumping(SX_mearec)
 
     def test_hs2_extractor(self):
         path1 = self.test_dir + '/firings_true.hdf5'
@@ -194,6 +205,7 @@ class TestExtractors(unittest.TestCase):
         self._check_sorting_return_types(SX_hs2)
         self._check_sortings_equal(self.SX, SX_hs2)
         self.assertEqual(SX_hs2.get_sampling_frequency(), self.SX.get_sampling_frequency())
+        self._check_dumping(SX_hs2)
 
     def test_exdir_extractors(self):
         path1 = self.test_dir + '/raw.exdir'
@@ -201,12 +213,14 @@ class TestExtractors(unittest.TestCase):
         RX_exdir = se.ExdirRecordingExtractor(path1)
         self._check_recording_return_types(RX_exdir)
         self._check_recordings_equal(self.RX, RX_exdir)
+        self._check_dumping(RX_exdir)
 
         path2 = self.test_dir + '/firings.exdir'
         se.ExdirSortingExtractor.write_sorting(self.SX, path2, self.RX)
         SX_exdir = se.ExdirSortingExtractor(path2)
         self._check_sorting_return_types(SX_exdir)
         self._check_sortings_equal(self.SX, SX_exdir)
+        self._check_dumping(SX_exdir)
 
     def test_kilosort_extractor(self):
         path1 = self.test_dir + '/ks'
@@ -214,6 +228,7 @@ class TestExtractors(unittest.TestCase):
         SX_ks = se.KiloSortSortingExtractor(path1)
         self._check_sorting_return_types(SX_ks)
         self._check_sortings_equal(self.SX, SX_ks)
+        self._check_dumping(SX_ks)
 
     def test_klusta_extractor(self):
         path1 = self.test_dir + '/firings_true.kwik'
@@ -221,6 +236,7 @@ class TestExtractors(unittest.TestCase):
         SX_kl = se.KlustaSortingExtractor(path1)
         self._check_sorting_return_types(SX_kl)
         self._check_sortings_equal(self.SX, SX_kl)
+        self._check_dumping(SX_kl)
 
     def test_spykingcircus_extractor(self):
         path1 = self.test_dir + '/sc'
@@ -228,6 +244,7 @@ class TestExtractors(unittest.TestCase):
         SX_spy = se.SpykingCircusSortingExtractor(path1)
         self._check_sorting_return_types(SX_spy)
         self._check_sortings_equal(self.SX, SX_spy)
+        self._check_dumping(SX_spy)
 
     def test_multi_sub_recording_extractor(self):
         RX_multi = se.MultiRecordingTimeExtractor(
@@ -271,6 +288,8 @@ class TestExtractors(unittest.TestCase):
         RX_nwb = se.NwbRecordingExtractor(path1)
         self._check_recording_return_types(RX_nwb)
         self._check_recordings_equal(self.RX, RX_nwb)
+        self._check_dumping(RX_nwb)
+
         del RX_nwb
         # overwrite
         se.NwbRecordingExtractor.write_recording(self.RX, path1, session_description='second',
@@ -278,6 +297,8 @@ class TestExtractors(unittest.TestCase):
         RX_nwb = se.NwbRecordingExtractor(path1)
         self._check_recording_return_types(RX_nwb)
         self._check_recordings_equal(self.RX, RX_nwb)
+        self._check_dumping(RX_nwb)
+
         # add sorting to existing
         se.NwbSortingExtractor.write_sorting(self.SX, path1)
         # create new
@@ -286,6 +307,7 @@ class TestExtractors(unittest.TestCase):
                                              identifier='19475')
         SX_nwb = se.NwbSortingExtractor(path1)
         self._check_sortings_equal(self.SX, SX_nwb)
+        self._check_dumping(SX_nwb)
 
     def test_nixio_extractor(self):
         path1 = os.path.join(self.test_dir, 'raw.nix')
@@ -293,6 +315,7 @@ class TestExtractors(unittest.TestCase):
         RX_nixio = se.NIXIORecordingExtractor(path1)
         self._check_recording_return_types(RX_nixio)
         self._check_recordings_equal(self.RX, RX_nixio)
+        self._check_dumping(RX_nixio)
         del RX_nixio
         # test force overwrite
         se.NIXIORecordingExtractor.write_recording(self.RX, path1,
@@ -303,6 +326,7 @@ class TestExtractors(unittest.TestCase):
         SX_nixio = se.NIXIOSortingExtractor(path2)
         self._check_sorting_return_types(SX_nixio)
         self._check_sortings_equal(self.SX, SX_nixio)
+        self._check_dumping(SX_nixio)
 
     def test_shybrid_extractors(self):
         # test sorting extractor
@@ -311,6 +335,7 @@ class TestExtractors(unittest.TestCase):
         SX_shybrid = se.SHYBRIDSortingExtractor(initial_sorting_file)
         self._check_sorting_return_types(SX_shybrid)
         self._check_sortings_equal(self.SX, SX_shybrid)
+        self._check_dumping(SX_shybrid)
 
         # test recording extractor
         se.SHYBRIDRecordingExtractor.write_recording(self.RX,
@@ -320,6 +345,7 @@ class TestExtractors(unittest.TestCase):
                                                                'recording.bin'))
         self._check_recording_return_types(RX_shybrid)
         self._check_recordings_equal(self.RX, RX_shybrid)
+        self._check_dumping(RX_shybrid)
 
     def _check_recordings_equal(self, RX1, RX2):
         M = RX1.get_num_channels()
@@ -375,6 +401,15 @@ class TestExtractors(unittest.TestCase):
             # print(train1)
             # print(train2)
             self.assertTrue(np.array_equal(train1, train2))
+
+    def _check_dumping(self, extractor):
+        extractor.dump(file_name='test.json')
+        extractor_loaded = se.load_extractor_from_json('test.json')
+
+        if 'Recording' in str(type(extractor)):
+            self._check_recordings_equal(extractor, extractor_loaded)
+        elif 'Sorting' in str(type(extractor)):
+            self._check_sortings_equal(extractor, extractor_loaded)
 
 
 if __name__ == '__main__':

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -282,6 +282,27 @@ class TestExtractors(unittest.TestCase):
         SX_sub1 = se.SubSortingExtractor(parent_sorting=SX_multi, start_frame=0, end_frame=N)
         self._check_sortings_equal(SX_multi, SX_sub1)
 
+    def test_dump_load_multi_sub_extractor(self):
+        # generate dumpable formats
+        path1 = self.test_dir + '/mda'
+        path2 = path1 + '/firings_true.mda'
+        se.MdaRecordingExtractor.write_recording(self.RX, path1)
+        se.MdaSortingExtractor.write_sorting(self.SX, path2)
+        RX_mda = se.MdaRecordingExtractor(path1)
+        SX_mda = se.MdaSortingExtractor(path2)
+
+        RX_multi_chan = se.MultiRecordingChannelExtractor(recordings=[RX_mda, RX_mda, RX_mda])
+        self._check_dumping(RX_multi_chan)
+        RX_multi_time = se.MultiRecordingTimeExtractor(recordings=[RX_mda, RX_mda, RX_mda],)
+        self._check_dumping(RX_multi_time)
+        RX_multi_chan = se.SubRecordingExtractor(RX_mda, channel_ids=[0, 1])
+        self._check_dumping(RX_multi_chan)
+
+        SX_sub = se.SubSortingExtractor(SX_mda, unit_ids=[1, 2])
+        self._check_dumping(SX_sub)
+        SX_multi = se.MultiSortingExtractor(sortings=[SX_mda, SX_mda, SX_mda])
+        self._check_dumping(SX_multi)
+
     def test_nwb_extractor(self):
         path1 = self.test_dir + '/test.nwb'
         se.NwbRecordingExtractor.write_recording(self.RX, path1)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -41,7 +41,7 @@ class TestTools(unittest.TestCase):
         n_group = 4
         for i in RX.get_channel_ids():
             channel_groups.append(i // n_group)
-        RX.set_channel_groups(RX.get_channel_ids(), channel_groups)
+        RX.set_channel_groups(channel_groups)
         RX.save_to_probe_file('tests/probe_test_no_groups.prb')
         RX.save_to_probe_file('tests/probe_test_groups.prb', grouping_property='group')
 


### PR DESCRIPTION
Implemented dump for MEArec, BinDat (and Cache), and Mda (recording and sorting)

The idea is to define the `self.kwargs` dictionary at initialization and dump the extractor_name and the params to json (from base extractors). The extractors can be reloaded with the `load_extractor_from_json` function.
Only extractor that have `is_dumpable` True can be dumped and loaded.

Minimal example:
```
import spikeextractors as se
import numpy as np

rec, sort = se.example_datasets.toy_example(duration=10, num_channels=4)
se.NumpyRecordingExtractor.is_dumpable  # no
se.MdaRecordingExtractor.is_dumpable  # yes

# save and load mda
se.MdaRecordingExtractor.write_recording(rec, 'rec_folder')
rec_mda = se.MdaRecordingExtractor('rec_folder')
rec_mda.dump()  # this saves 'spikeinterface_recording.json'

# load from json
rec_mda_loaded = se.load_extractor_from_json('spikeinterface_recording.json')
assert np.array_equal(rec_mda.get_traces(), rec_mda_loaded.get_traces())
```