### PR TITLE
Fix get_dtype

### DIFF
--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -100,7 +100,7 @@ class RecordingExtractor(ABC):
         return len(self.get_channel_ids())
 
     def get_dtype(self):
-        return self.get_traces(channel_ids=self.get_channel_ids()[0], start_frame=0, end_frame=1).dtype
+        return self.get_traces(channel_ids=[self.get_channel_ids()[0]], start_frame=0, end_frame=1).dtype
 
     def frame_to_time(self, frame):
         '''This function converts a user-inputted frame index to a time with units of seconds.


### PR DESCRIPTION
The `get_dtype` function passes now a list of one channel. This should solve several downstream problems as `channel_ids` is often assumed to be a list.