### PR TITLE
keep_good_only False by default

### DIFF
--- a/spikeextractors/extractors/kilosortextractors/kilosortextractors.py
+++ b/spikeextractors/extractors/kilosortextractors/kilosortextractors.py
@@ -28,7 +28,7 @@ class KiloSortSortingExtractor(PhySortingExtractor):
     is_writable = True
     mode = 'folder'
 
-    def __init__(self, folder_path, exclude_cluster_groups=None, load_waveforms=False, keep_good_only=True,
+    def __init__(self, folder_path, exclude_cluster_groups=None, load_waveforms=False, keep_good_only=False,
                  verbose=False):
         PhySortingExtractor.__init__(self, folder_path, exclude_cluster_groups, load_waveforms, verbose)
         self._keep_good_only = keep_good_only


### PR DESCRIPTION
The `keep_good_only` param should be False by default. It's much easier to filter good units after than the opposite, since they are saved as `KSLabel` property. One can simply do:

```
good_units = []
for u in sort_ks.get_unit_ids():
    if sort_ks.get_unit_property(u, 'KSLabel') == 'good':
        good_units.append(u)

sort_good = se.SubSortingExtractor(sort_ks, unit_ids=good_units)
```