### PR TITLE
Memmap

### DIFF
--- a/spikeextractors/cacherecordingextractor.py
+++ b/spikeextractors/cacherecordingextractor.py
@@ -1,23 +1,27 @@
 from spikeextractors.extractors.bindatrecordingextractor import BinDatRecordingExtractor
+from spikeextractors import RecordingExtractor
 import tempfile
 from pathlib import Path
 import os
 import shutil
 
 
-class CacheRecordingExtractor(BinDatRecordingExtractor):
+class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
 
     extractor_name = 'CacheRecordingExtractor'
 
-    def __init__(self, recording, chunk_size=None, output_folder=None):
+    def __init__(self, recording, chunk_size=None):
+        RecordingExtractor.__init__(self)  # init tmp folder before constructing BinDatRecordingExtractor
+        tmp_folder = self.get_tmp_folder()
         self._recording = recording
-        self._tmp_file = tempfile.NamedTemporaryFile(suffix=".dat", dir=output_folder).name
+        self._tmp_file = tempfile.NamedTemporaryFile(suffix=".dat", dir=tmp_folder).name
         dtype = recording.get_traces(start_frame=0, end_frame=2).dtype
         recording.write_to_binary_dat_format(save_path=self._tmp_file, dtype=dtype, chunk_size=chunk_size)
         BinDatRecordingExtractor.__init__(self, self._tmp_file, numchan=recording.get_num_channels(),
                                           recording_channels=recording.get_channel_ids(),
                                           sampling_frequency=recording.get_sampling_frequency(),
                                           dtype=dtype)
+        self.set_tmp_folder(tmp_folder)
         self.copy_channel_properties(recording)
 
     def __del__(self):
@@ -26,7 +30,8 @@ class CacheRecordingExtractor(BinDatRecordingExtractor):
         except Exception as e:
             print("Unable to remove temporary file", e)
 
-    def get_filename(self):
+    @property
+    def filename(self):
         return self._tmp_file
 
     def save_to_file(self, save_path):

--- a/spikeextractors/cacherecordingextractor.py
+++ b/spikeextractors/cacherecordingextractor.py
@@ -1,7 +1,8 @@
 from spikeextractors.extractors.bindatrecordingextractor import BinDatRecordingExtractor
 import tempfile
 from pathlib import Path
-import os, shutil
+import os
+import shutil
 
 
 class CacheRecordingExtractor(BinDatRecordingExtractor):
@@ -22,8 +23,8 @@ class CacheRecordingExtractor(BinDatRecordingExtractor):
     def __del__(self):
         try:
             os.remove(self._tmp_file)
-        except Exception:
-            print("Unable to remove temporary file")
+        except Exception as e:
+            print("Unable to remove temporary file", e)
 
     def get_filename(self):
         return self._tmp_file

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -356,10 +356,8 @@ def get_sub_extractors_by_property(extractor, property_name, return_property_lis
     sub_list, prop_list
         If return_property_list is True, the property list will be returned as well.
     '''
-    from .recordingextractor import RecordingExtractor
-    from .sortingextractor import SortingExtractor
-    from .subrecordingextractor import SubRecordingExtractor
-    from .subsortingextractor import SubSortingExtractor
+    from spikeextractors import RecordingExtractor, SortingExtractor, SubRecordingExtractor, SubSortingExtractor
+
     if isinstance(extractor, RecordingExtractor):
         if property_name not in extractor.get_shared_channel_property_names():
             raise ValueError("'property_name' must be must be a property of the recording channels")

--- a/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
+++ b/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
@@ -1,6 +1,7 @@
 from spikeextractors import RecordingExtractor
 from spikeextractors.extraction_tools import read_binary, write_to_binary_dat_format
 import os
+import shutil
 import numpy as np
 from pathlib import Path
 
@@ -72,6 +73,37 @@ class BinDatRecordingExtractor(RecordingExtractor):
         if self._gain is not None:
             recordings = recordings * self._gain
         return recordings
+
+    def write_to_binary_dat_format(self, save_path, time_axis=0, dtype=None, chunk_size=None, chunk_mb=500):
+        '''Saves the traces of this recording extractor into binary .dat format.
+
+        Parameters
+        ----------
+        save_path: str
+            The path to the file.
+        time_axis: 0 (default) or 1
+            If 0 then traces are transposed to ensure (nb_sample, nb_channel) in the file.
+            If 1, the traces shape (nb_channel, nb_sample) is kept in the file.
+        dtype: dtype
+            Type of the saved data. Default float32
+        chunk_size: None or int
+            If not None then the file is saved in chunks.
+            This avoid to much memory consumption for big files.
+            If 'auto' the file is saved in chunks of ~ 500Mb
+        chunk_mb: None or int
+            Chunk size in Mb (default 500Mb)
+        '''
+        if dtype is None or dtype == self.get_dtype():
+            try:
+                shutil.copy(self._datfile, save_path)
+            except Exception as e:
+                print('Error occurred while copying:', e)
+                print('Writing to binary')
+                write_to_binary_dat_format(self, save_path=save_path, time_axis=time_axis, dtype=dtype,
+                                           chunk_size=chunk_size, chunk_mb=chunk_mb)
+        else:
+            write_to_binary_dat_format(self, save_path=save_path, time_axis=time_axis, dtype=dtype,
+                                       chunk_size=chunk_size, chunk_mb=chunk_mb)
 
     @staticmethod
     def write_recording(recording, save_path, time_axis=0, dtype=None, chunk_size=None):

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -176,14 +176,8 @@ class RecordingExtractor(ABC):
         num_channels = len(channel_ids)
         num_frames = self.get_num_frames()
         snippet_len_total = snippet_len_before + snippet_len_after
-        # snippets = []
         snippets = np.zeros((num_snippets, num_channels, snippet_len_total))
-        #TODO extract all waveforms in a chunk
-        pad_first = False
-        pad_last = False
-        pad_samples_first = 0
-        pad_samples_last = 0
-        snippet_idxs = np.array([], dtype=int)
+
         for i in range(num_snippets):
             snippet_chunk = np.zeros((num_channels, snippet_len_total))
             if (0 <= reference_frames[i]) and (reference_frames[i] < num_frames):

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -740,8 +740,8 @@ class RecordingExtractor(ABC):
         dtype: dtype
             Dtype of the array
         memmap: bool
-            If True, array is memmaped
-        name: str
+            If True, a memmap array is created in the recording temporary folder
+        name: str or None
             Name (root) of the file (if memmap is True)
 
         Returns
@@ -752,8 +752,13 @@ class RecordingExtractor(ABC):
         if memmap:
             tmp_folder = self.get_tmp_folder()
             if name is None:
-                name = ''.join([random.choice(string.ascii_letters) for i in range(5)])
-            arr = np.memmap(tmp_folder / (name + '.raw'), shape=shape, dtype=dtype)
+                tmp_file = tempfile.NamedTemporaryFile(suffix=".raw", dir=tmp_folder).name
+            else:
+                if Path(name).suffix == '':
+                    tmp_file = tmp_folder / (name + '.raw')
+                else:
+                    tmp_file = tmp_folder / name
+            arr = np.memmap(tmp_file, mode='w+', shape=shape, dtype=dtype)
             arr[:] = 0
         else:
             arr = np.zeros(shape, dtype=dtype)

--- a/spikeextractors/sortingextractor.py
+++ b/spikeextractors/sortingextractor.py
@@ -669,8 +669,8 @@ class SortingExtractor(ABC):
         dtype: dtype
             Dtype of the array
         memmap: bool
-            If True, array is memmaped
-        name: str
+            If True, a memmap array is created in the sorting temporary folder
+        name: str or None
             Name (root) of the file (if memmap is True)
 
         Returns
@@ -681,8 +681,13 @@ class SortingExtractor(ABC):
         if memmap:
             tmp_folder = self.get_tmp_folder()
             if name is None:
-                name = ''.join([random.choice(string.ascii_letters) for i in range(5)])
-            arr = np.memmap(tmp_folder / (name + '.raw'), shape=shape, dtype=dtype)
+                tmp_file = tempfile.NamedTemporaryFile(suffix=".raw", dir=tmp_folder).name
+            else:
+                if Path(name).suffix == '':
+                    tmp_file = tmp_folder / (name + '.raw')
+                else:
+                    tmp_file = tmp_folder / name
+            arr = np.memmap(tmp_file, mode='w+', shape=shape, dtype=dtype)
             arr[:] = 0
         else:
             arr = np.zeros(shape, dtype=dtype)

--- a/spikeextractors/sortingextractor.py
+++ b/spikeextractors/sortingextractor.py
@@ -658,20 +658,23 @@ class SortingExtractor(ABC):
         '''
         self._tmp_folder = Path(folder)
 
-    def allocate_array(self, shape, dtype, memmap, name=None):
+    def allocate_array(self, memmap, shape=None, dtype=None, name=None, array=None):
         '''
         Allocates a memory or memmap array
 
         Parameters
         ----------
-        shape: tuple
-            Shape of the array
-        dtype: dtype
-            Dtype of the array
         memmap: bool
             If True, a memmap array is created in the sorting temporary folder
+        shape: tuple
+            Shape of the array. If None array must be given
+        dtype: dtype
+            Dtype of the array. If None array must be given
         name: str or None
-            Name (root) of the file (if memmap is True)
+            Name (root) of the file (if memmap is True). If None, a random name is generated
+        array: np.array
+            If array is given, shape and dtype are initialized based on the array. If memmap is True, the array is then
+            deleted to clear memory
 
         Returns
         -------
@@ -680,6 +683,11 @@ class SortingExtractor(ABC):
         '''
         if memmap:
             tmp_folder = self.get_tmp_folder()
+            if array is not None:
+                shape = array.shape
+                dtype = array.dtype
+            else:
+                assert shape is not None and dtype is not None, "Pass 'shape' and 'dtype' arguments"
             if name is None:
                 tmp_file = tempfile.NamedTemporaryFile(suffix=".raw", dir=tmp_folder).name
             else:
@@ -688,9 +696,16 @@ class SortingExtractor(ABC):
                 else:
                     tmp_file = tmp_folder / name
             arr = np.memmap(tmp_file, mode='w+', shape=shape, dtype=dtype)
-            arr[:] = 0
+            if array is not None:
+                arr[:] = array
+                del array
+            else:
+                arr[:] = 0
         else:
-            arr = np.zeros(shape, dtype=dtype)
+            if array is not None:
+                arr = array
+            else:
+                arr = np.zeros(shape, dtype=dtype)
         return arr
 
     @staticmethod

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -114,7 +114,7 @@ class TestExtractors(unittest.TestCase):
         self._check_recordings_equal(self.RX, cache_extractor)
         cache_extractor.save_to_file('cache')
 
-        assert cache_extractor.get_filename() == 'cache.dat'
+        assert cache_extractor.filename == 'cache.dat'
         del cache_extractor
         assert not Path('cache.dat').is_file()
 

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -108,6 +108,30 @@ class TestExtractors(unittest.TestCase):
 
         self._check_recording_return_types(self.RX)
 
+    def test_allocate_arrays(self):
+        shape = (30, 1000)
+        dtype = 'int16'
+
+        arr_in_memory = self.RX.allocate_array(shape=shape, dtype=dtype, memmap=False)
+        arr_memmap = self.RX.allocate_array(shape=shape, dtype=dtype, memmap=True)
+
+        assert isinstance(arr_in_memory, np.ndarray)
+        assert isinstance(arr_memmap, np.memmap)
+        assert arr_in_memory.shape == shape
+        assert arr_memmap.shape == shape
+        assert arr_in_memory.dtype == dtype
+        assert arr_memmap.dtype == dtype
+
+        arr_in_memory = self.SX.allocate_array(shape=shape, dtype=dtype, memmap=False)
+        arr_memmap = self.SX.allocate_array(shape=shape, dtype=dtype, memmap=True)
+
+        assert isinstance(arr_in_memory, np.ndarray)
+        assert isinstance(arr_memmap, np.memmap)
+        assert arr_in_memory.shape == shape
+        assert arr_memmap.shape == shape
+        assert arr_in_memory.dtype == dtype
+        assert arr_memmap.dtype == dtype
+
     def test_cache_extractor(self):
         cache_extractor = se.CacheRecordingExtractor(self.RX)
         self._check_recording_return_types(cache_extractor)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -86,19 +86,5 @@ class TestTools(unittest.TestCase):
         assert np.allclose(data, self.RX.get_traces())
         del (data)  # this close the file
 
-    def test_allocate_arrays(self):
-        shape = (30, 1000)
-        dtype = 'int16'
-
-        arr_in_memory = self.RX.allocate_array(shape=shape, dtype=dtype, memmap=False)
-        arr_memmap = self.RX.allocate_array(shape=shape, dtype=dtype, memmap=True)
-
-        assert isinstance(arr_in_memory, np.ndarray)
-        assert isinstance(arr_memmap, np.memmap)
-        assert arr_in_memory.shape == shape
-        assert arr_memmap.shape == shape
-        assert arr_in_memory.dtype == dtype
-        assert arr_memmap.dtype == dtype
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -86,6 +86,19 @@ class TestTools(unittest.TestCase):
         assert np.allclose(data, self.RX.get_traces())
         del (data)  # this close the file
 
+    def test_allocate_arrays(self):
+        shape = (30, 1000)
+        dtype = 'int16'
+
+        arr_in_memory = self.RX.allocate_array(shape=shape, dtype=dtype, memmap=False)
+        arr_memmap = self.RX.allocate_array(shape=shape, dtype=dtype, memmap=True)
+
+        assert isinstance(arr_in_memory, np.ndarray)
+        assert isinstance(arr_memmap, np.memmap)
+        assert arr_in_memory.shape == shape
+        assert arr_memmap.shape == shape
+        assert arr_in_memory.dtype == dtype
+        assert arr_memmap.dtype == dtype
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is to enable the creation of memmap arrays for sorting extractors for waveforms, pca scores, amplitudes, etc

- added self._tmp_folder (+set-get)
- modified set get features so that it does force conversion to in-memory numpy array