### PR TITLE
Proposal for pickle load/dump

### DIFF
--- a/spikeextractors/baseextractor.py
+++ b/spikeextractors/baseextractor.py
@@ -9,9 +9,17 @@ import datetime
 class BaseExtractor:
     is_dumpable = True
 
-    def __init__(self):
+    def __init__(self, *args, **kargs):
         self._kwargs = {}
         self._tmp_folder = None
+        
+        self.
+    
+    def _init_extractor(self, *args, **kargs):
+        # this remplace the init in each class
+        # this is call both at __init__ but also in __setstate__ (when pickle.load)
+        raise NotImplementedError
+    
 
     def make_serialized_dict(self):
         class_name = str(type(self)).replace("<class '", "").replace("'>", '')
@@ -105,6 +113,12 @@ class BaseExtractor:
 
     def check_if_dumpable(self):
         return _check_if_dumpable(self.make_serialized_dict())
+    
+    def __getstate__(self):
+        return self.make_serialized_dict()
+
+    def __setstate__(self, d):
+        self._init_extractor(**d)
 
 
 def _load_extractor_from_dict(dic):

--- a/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
+++ b/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
@@ -26,7 +26,7 @@ class BinDatRecordingExtractor(RecordingExtractor):
     ]
     installation_mesg = ""  # error message when not installed
 
-    def __init__(self, file_path, sampling_frequency, numchan, dtype, recording_channels=None,
+    def _init_extractor(self, file_path, sampling_frequency, numchan, dtype, recording_channels=None,
                  time_axis=0, geom=None, offset=0, gain=None):
         RecordingExtractor.__init__(self)
         self._datfile = Path(file_path)

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import unittest
 import tempfile
 import shutil
+import pickle
+
 import spikeextractors as se
 
 
@@ -424,6 +426,7 @@ class TestExtractors(unittest.TestCase):
             self.assertTrue(np.array_equal(train1, train2))
 
     def _check_dumping(self, extractor):
+        # json style
         extractor.dump(file_name='test.json')
         extractor_loaded = se.load_extractor_from_json('test.json')
 
@@ -431,6 +434,12 @@ class TestExtractors(unittest.TestCase):
             self._check_recordings_equal(extractor, extractor_loaded)
         elif 'Sorting' in str(type(extractor)):
             self._check_sortings_equal(extractor, extractor_loaded)
+        
+        
+        # with pickle
+        s = pickle.dumps(extractor)
+        extractor2 = pickle.loads(s)
+        
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi all.
@alejoe91 @colehurwitz @magland 

This is a proposal to make pickle/load for extactor.
Alessio have already merge a system that make possible to dump/load with json all extactors.
Including nested extactors for instance after a filter.

This is an extention to the previous PR to also use this system with pickle (usefull with joblib/multiprocessing for instance).

The main problem is that we need to hack the ```__init__``` in all extactor and replace with ```_init_extractor```.

Please have a look to baseextactor and BinDatRecordingExtractor that have no more init.

Then we can extend this to all extractors.







