### PR TITLE
Proposal: get_traces decorator

### DIFF
--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -604,22 +604,23 @@ def check_get_traces_args(func):
             channel_ids = recording.get_channel_ids()
         if start_frame is not None:
             if start_frame < 0:
-                print("'start_time' set to", 0)
-                start_frame = 0
+                start_frame = recording.get_num_frames() - start_frame
         else:
             start_frame = 0
         if end_frame is not None:
             if end_frame > recording.get_num_frames():
                 print("'end_time' set to", recording.get_num_frames())
                 end_frame = recording.get_num_frames()
+            elif end_frame < 0:
+                end_frame = recording.get_num_frames() - end_frame
         else:
             end_frame = recording.get_num_frames()
-        assert end_frame - start_frame > 0, "'start_frame' is equal of greater than 'end_frame'!"
-        _cast_start_end_frame(recording, start_frame, end_frame)
+        assert end_frame - start_frame > 0, "'start_frame' must be less than 'end_frame'!"
+        cast_start_end_frame(start_frame, end_frame)
         kwargs['channel_ids'] = channel_ids
         kwargs['start_frame'] = start_frame
         kwargs['end_frame'] = end_frame
-        
+
         # pass recording as arg and rest as kwargs
         get_traces_correct_arg = func(args[0], **kwargs)
 
@@ -627,7 +628,7 @@ def check_get_traces_args(func):
     return corrected_args
 
 
-def _cast_start_end_frame(self, start_frame, end_frame):
+def cast_start_end_frame(start_frame, end_frame):
     if isinstance(start_frame, (float, np.float)):
         start_frame = int(start_frame)
     elif isinstance(start_frame, (int, np.integer, type(None))):

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -604,7 +604,7 @@ def check_get_traces_args(func):
             channel_ids = recording.get_channel_ids()
         if start_frame is not None:
             if start_frame < 0:
-                start_frame = recording.get_num_frames() - start_frame
+                start_frame = recording.get_num_frames() + start_frame
         else:
             start_frame = 0
         if end_frame is not None:
@@ -612,7 +612,7 @@ def check_get_traces_args(func):
                 print("'end_time' set to", recording.get_num_frames())
                 end_frame = recording.get_num_frames()
             elif end_frame < 0:
-                end_frame = recording.get_num_frames() - end_frame
+                end_frame = recording.get_num_frames() + end_frame
         else:
             end_frame = recording.get_num_frames()
         assert end_frame - start_frame > 0, "'start_frame' must be less than 'end_frame'!"

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -573,11 +573,23 @@ def check_get_traces_args(func):
         start_frame = kwargs.get('start_frame', 0)
         end_frame = kwargs.get('end_frame', recording.get_num_frames())
 
-        assert np.all([ch in recording.get_channel_ids() for ch in channel_ids])
-        if start_frame < 0:
+        if channel_ids is not None:
+            if np.any([ch not in recording.get_channel_ids() for ch in channel_ids]):
+                print('Removing invalid channels')
+                channel_ids = [ch for ch in channel_ids if ch in recording.get_channel_ids()]
+        else:
+            channel_ids = recording.get_channel_ids()
+        if start_frame is not None:
+            if start_frame < 0:
+                start_frame = 0
+        else:
             start_frame = 0
-        if end_frame > recording.get_num_frames():
+        if end_frame is not None:
+            if end_frame > recording.get_num_frames():
+                end_frame = recording.get_num_frames()
+        else:
             end_frame = recording.get_num_frames()
+        assert end_frame - start_frame > 0, "'start_frame' is equal of greater than 'end_frame'!"
         _cast_start_end_frame(recording, start_frame, end_frame)
         kwargs['channel_ids'] = channel_ids
         kwargs['start_frame'] = start_frame

--- a/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
+++ b/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
@@ -1,8 +1,6 @@
 from spikeextractors import RecordingExtractor
-from spikeextractors.extraction_tools import read_binary, write_to_binary_dat_format
-import os
+from spikeextractors.extraction_tools import read_binary, write_to_binary_dat_format, check_get_traces_args
 import shutil
-import numpy as np
 from pathlib import Path
 
 
@@ -61,16 +59,8 @@ class BinDatRecordingExtractor(RecordingExtractor):
     def get_sampling_frequency(self):
         return self._sampling_frequency
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
-        if channel_ids is None:
-            channel_ids = list(range(self._timeseries.shape[0]))
-        else:
-            channel_ids = [self._channels.index(ch) for ch in channel_ids]
         recordings = self._timeseries[:, start_frame:end_frame][channel_ids, :]
         if self._dtype.startswith('uint'):
             exp_idx = self._dtype.find('int') + 3

--- a/spikeextractors/extractors/exdirextractors/exdirextractors.py
+++ b/spikeextractors/extractors/exdirextractors/exdirextractors.py
@@ -3,6 +3,8 @@ from spikeextractors import SortingExtractor
 import numpy as np
 from pathlib import Path
 from copy import copy
+from spikeextractors.extraction_tools import check_get_traces_args
+
 
 try:
     import exdir
@@ -48,8 +50,8 @@ class ExdirRecordingExtractor(RecordingExtractor):
     def get_sampling_frequency(self):
         return self._sampling_frequency
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:
             start_frame = 0
         if end_frame is None:

--- a/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
+++ b/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
@@ -1,5 +1,5 @@
 from spikeextractors import RecordingExtractor, SortingExtractor
-import numpy as np
+from spikeextractors.extraction_tools import check_get_traces_args
 from pathlib import Path
 
 try:
@@ -39,13 +39,6 @@ class IntanRecordingExtractor(RecordingExtractor):
     def get_sampling_frequency(self):
         return float(self._recording.sample_rate.rescale('Hz').magnitude)
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
-        if channel_ids is None:
-            channel_ids = self.get_channel_ids()
-
         return self._recording.analog_signals[0].signal[channel_ids, start_frame:end_frame]

--- a/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
+++ b/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
@@ -1,6 +1,7 @@
 from spikeextractors import RecordingExtractor
 from pathlib import Path
 import numpy as np
+from spikeextractors.extraction_tools import check_get_traces_args
 
 try:
     import h5py
@@ -57,14 +58,8 @@ class MaxOneRecordingExtractor(RecordingExtractor):
     def get_sampling_frequency(self):
         return self._fs
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
-        if channel_ids is None:
-            channel_ids = self.get_channel_ids()
         if np.array(channel_ids).size > 1:
             assert np.all([ch in self.get_channel_ids() for ch in channel_ids])
             channel_idxs = [self.get_channel_ids().index(ch) for ch in channel_ids]

--- a/spikeextractors/extractors/mcsh5recordingextractor/mcsh5recordingextractor.py
+++ b/spikeextractors/extractors/mcsh5recordingextractor/mcsh5recordingextractor.py
@@ -1,6 +1,7 @@
 from spikeextractors import RecordingExtractor
 import numpy as np
 from pathlib import Path
+from spikeextractors.extraction_tools import check_get_traces_args
 
 try:
     import h5py
@@ -70,26 +71,18 @@ class MCSH5RecordingExtractor(RecordingExtractor):
             analog_stream_names = list(rf.require_group('/Data/Recording_0/AnalogStream').keys())
             return list(range(len(analog_stream_names)))
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:
             start_frame = 0
         if end_frame is None:
             end_frame = self.get_num_frames()
-        if channel_ids is None:
-            channel_idxs = []
-            for m in self._channel_ids:
-                assert m in self._channel_ids, 'channel_id {} not found'.format(m)
-                channel_idxs.append(np.where(np.array(self._channel_ids) == m)[0][0])
-        else:
-            if isinstance(channel_ids, (int, np.integer)):
-                assert channel_ids in self._channel_ids, 'channel_id {} not found'.format(channel_ids)
-                channel_idxs = np.where(np.array(self._channel_ids) == channel_ids)[0][0]
-            else:
-                channel_idxs = []
-                for m in channel_ids:
-                    assert m in self._channel_ids, 'channel_id {} not found'.format(m)
-                    channel_idxs.append(np.where(np.array(self._channel_ids) == m)[0][0])
+
+        channel_idxs = []
+        for m in channel_ids:
+            assert m in self._channel_ids, 'channel_id {} not found'.format(m)
+            channel_idxs.append(np.where(np.array(self._channel_ids) == m)[0][0])
 
         stream = self._rf.require_group('/Data/Recording_0/AnalogStream/Stream_' + str(self._stream_id))
         conv = self._convFact.astype(float) * (10.0 ** self._exponent)

--- a/spikeextractors/extractors/mdaextractors/mdaextractors.py
+++ b/spikeextractors/extractors/mdaextractors/mdaextractors.py
@@ -1,6 +1,6 @@
 from spikeextractors import RecordingExtractor
 from spikeextractors import SortingExtractor
-from ...extraction_tools import write_to_binary_dat_format
+from ...extraction_tools import write_to_binary_dat_format, check_get_traces_args
 
 import json
 import numpy as np
@@ -43,7 +43,6 @@ class MdaRecordingExtractor(RecordingExtractor):
         for m in range(self._num_channels):
             self.set_channel_property(m, 'location', self._geom[m, :])
         self._kwargs = {'folder_path': str(Path(folder_path).absolute())}
-        #self.append_to_dump_dict()
 
     def get_channel_ids(self):
         return list(range(self._num_channels))
@@ -54,14 +53,8 @@ class MdaRecordingExtractor(RecordingExtractor):
     def get_sampling_frequency(self):
         return self._sampling_frequency
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
-        if channel_ids is None:
-            channel_ids = self.get_channel_ids()
         X = DiskReadMda(self._timeseries_path)
         recordings = X.readChunk(i1=0, i2=start_frame, N1=X.N1(), N2=end_frame - start_frame)
         recordings = recordings[channel_ids, :]

--- a/spikeextractors/extractors/mdaextractors/mdaextractors.py
+++ b/spikeextractors/extractors/mdaextractors/mdaextractors.py
@@ -1,6 +1,6 @@
 from spikeextractors import RecordingExtractor
 from spikeextractors import SortingExtractor
-from ...extraction_tools import write_to_binary_dat_format, check_get_traces_args
+from spikeextractors.extraction_tools import write_to_binary_dat_format, check_get_traces_args
 
 import json
 import numpy as np

--- a/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
+++ b/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
@@ -1,6 +1,7 @@
 from spikeextractors import RecordingExtractor
 from pathlib import Path
 import numpy as np
+from spikeextractors.extraction_tools import check_get_traces_args
 
 try:
     import h5py
@@ -58,14 +59,8 @@ class Mea1kRecordingExtractor(RecordingExtractor):
     def get_sampling_frequency(self):
         return self._fs
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
-        if channel_ids is None:
-            channel_ids = self.get_channel_ids()
         if np.array(channel_ids).size > 1:
             assert np.all([ch in self.get_channel_ids() for ch in channel_ids])
             channel_idxs = [self.get_channel_ids().index(ch) for ch in channel_ids]

--- a/spikeextractors/extractors/mearecextractors/mearecextractors.py
+++ b/spikeextractors/extractors/mearecextractors/mearecextractors.py
@@ -1,5 +1,6 @@
 from spikeextractors import RecordingExtractor
 from spikeextractors import SortingExtractor
+from spikeextractors.extraction_tools import check_get_traces_args
 
 import numpy as np
 from pathlib import Path
@@ -76,14 +77,8 @@ class MEArecRecordingExtractor(RecordingExtractor):
     def get_sampling_frequency(self):
         return self._fs
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
-        if channel_ids is None:
-            channel_ids = list(range(self.get_num_channels()))
         if np.array(channel_ids).size > 1:
             if np.any(np.diff(channel_ids) < 0):
                 sorted_idx = np.argsort(channel_ids)

--- a/spikeextractors/extractors/neoextractors/neobaseextractor.py
+++ b/spikeextractors/extractors/neoextractors/neobaseextractor.py
@@ -3,7 +3,7 @@ import neo
 
 from spikeextractors import RecordingExtractor
 from spikeextractors import SortingExtractor
-
+from spikeextractors.extraction_tools import check_get_traces_args
 
 class _NeoBaseExtractor:
     NeoRawIOClass = None
@@ -64,8 +64,8 @@ class NeoBaseRecordingExtractor(RecordingExtractor, _NeoBaseExtractor):
         self.additional_gain[units == 'uV'] = 1.
         self.additional_gain = self.additional_gain.reshape(1, -1)
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         # in neo rawio channel can acces by names/ids/indexes
         # there is no garranty that ids/names are unique on some formats
         raw_traces = self.neo_reader.get_analogsignal_chunk(block_index=self.block_index, seg_index=self.seg_index,

--- a/spikeextractors/extractors/nixioextractors/nixioextractors.py
+++ b/spikeextractors/extractors/nixioextractors/nixioextractors.py
@@ -10,6 +10,7 @@ except ImportError:
 
 from spikeextractors import RecordingExtractor
 from spikeextractors import SortingExtractor
+from spikeextractors.extraction_tools import check_get_traces_args
 
 # error message when not installed
 missing_nixio_msg = ("To use the NIXIORecordingExtractor install nixio:"
@@ -62,12 +63,9 @@ class NIXIORecordingExtractor(RecordingExtractor):
         sampling_frequency = 1./timedim.sampling_interval
         return sampling_frequency
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if channel_ids:
-            channels = np.array([self._traces[cid] for cid in channel_ids])
-        else:
-            channels = self._traces[:]
+        channels = np.array([self._traces[cid] for cid in channel_ids])
         return channels[:, start_frame:end_frame]
 
     def _load_properties(self):

--- a/spikeextractors/extractors/numpyextractors/numpyextractors.py
+++ b/spikeextractors/extractors/numpyextractors/numpyextractors.py
@@ -19,8 +19,12 @@ class NumpyRecordingExtractor(RecordingExtractor):
             if Path(timeseries).is_file():
                 self.is_dumpable = True
                 self._timeseries = np.load(timeseries)
+                self._kwargs = {'timeseries': str(Path(timeseries).absolute()),
+                                'sampling_frequency': sampling_frequency, 'geom': geom}
         elif isinstance(timeseries, np.ndarray):
             self._timeseries = timeseries
+            self._kwargs = {'timeseries': timeseries,
+                            'sampling_frequency': sampling_frequency, 'geom': geom}
         else:
             raise TypeError("'timeseries must be a .npy file name or a numpy array")
         RecordingExtractor.__init__(self)
@@ -29,6 +33,7 @@ class NumpyRecordingExtractor(RecordingExtractor):
         if geom is not None:
             for m in range(self._timeseries.shape[0]):
                 self.set_channel_property(m, 'location', self._geom[m, :])
+
 
     def get_channel_ids(self):
         return list(range(self._timeseries.shape[0]))

--- a/spikeextractors/extractors/numpyextractors/numpyextractors.py
+++ b/spikeextractors/extractors/numpyextractors/numpyextractors.py
@@ -2,6 +2,7 @@ from spikeextractors import RecordingExtractor
 from spikeextractors import SortingExtractor
 from pathlib import Path
 import numpy as np
+from spikeextractors.extraction_tools import check_get_traces_args
 
 '''
 The NumpyExtractors can be constructed and used to encapsulate custom file formats and data structures which
@@ -34,7 +35,6 @@ class NumpyRecordingExtractor(RecordingExtractor):
             for m in range(self._timeseries.shape[0]):
                 self.set_channel_property(m, 'location', self._geom[m, :])
 
-
     def get_channel_ids(self):
         return list(range(self._timeseries.shape[0]))
 
@@ -44,14 +44,8 @@ class NumpyRecordingExtractor(RecordingExtractor):
     def get_sampling_frequency(self):
         return self._sampling_frequency
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
-        if channel_ids is None:
-            channel_ids = self.get_channel_ids()
         recordings = self._timeseries[:, start_frame:end_frame][channel_ids, :]
         return recordings
 

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -3,11 +3,10 @@ import uuid
 from datetime import datetime
 from collections import defaultdict
 from pathlib import Path
-
 import numpy as np
 
-
 import spikeextractors as se
+from spikeextractors.extraction_tools import check_get_traces_args
 
 try:
     from pynwb import NWBHDF5IO
@@ -211,25 +210,9 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                     for _, row in df_epochs.iterrows()}
         self._kwargs = {'file_path': str(Path(file_path).absolute()), 'electrical_series_name': electrical_series_name}
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         check_nwb_install()
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if channel_ids is not None:
-            if not isinstance(channel_ids, (list, np.ndarray)):
-                raise TypeError("'channel_ids' must be a list or array of integers.")
-            if not all([id in self.channel_ids for id in channel_ids]):
-                raise ValueError("'channel_ids' contain values outside the range of valid ids.")
-        else:
-            channel_ids = self.channel_ids
-        if start_frame is not None:
-            if not isinstance(start_frame, (int, np.integer)):
-                raise TypeError("'start_frame' must be an integer")
-        else:
-            start_frame = 0
-        if end_frame is not None:
-            if not isinstance(end_frame, (int, np.integer)):
-                raise TypeError("'end_frame' must be an integer")
-
         with NWBHDF5IO(self._path, 'r') as io:
             nwbfile = io.read()
             es = nwbfile.acquisition[self._electrical_series_name]

--- a/spikeextractors/extractors/openephysextractors/openephysextractors.py
+++ b/spikeextractors/extractors/openephysextractors/openephysextractors.py
@@ -1,6 +1,7 @@
 from spikeextractors import RecordingExtractor, SortingExtractor
 from pathlib import Path
 import numpy as np
+from spikeextractors.extraction_tools import check_get_traces_args
 
 try:
     import pyopenephys
@@ -45,14 +46,8 @@ class OpenEphysRecordingExtractor(RecordingExtractor):
     def get_sampling_frequency(self):
         return float(self._recording.sample_rate.rescale('Hz').magnitude)
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
-        if channel_ids is None:
-            channel_ids = self.get_channel_ids()
         if self._dtype == 'int16':
             return self._recording.analog_signals[0].signal[channel_ids, start_frame:end_frame]
         elif self._dtype == 'float':

--- a/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
@@ -2,6 +2,7 @@ from spikeextractors import RecordingExtractor
 from .readSGLX import readMeta, SampRate, makeMemMapRaw, GainCorrectIM, GainCorrectNI
 import numpy as np
 from pathlib import Path
+from spikeextractors.extraction_tools import check_get_traces_args
 
 
 class SpikeGLXRecordingExtractor(RecordingExtractor):
@@ -77,17 +78,10 @@ class SpikeGLXRecordingExtractor(RecordingExtractor):
     def get_sampling_frequency(self):
         return self._sampling_frequency
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
-        if channel_ids is None:
-            channel_ids = list(range(self._timeseries.shape[0]))
-        else:
-            channel_ids = [self._channels.index(ch) for ch in channel_ids]
-        recordings = self._timeseries[channel_ids, start_frame:end_frame]
+        channel_idxs = [self._channels.index(ch) for ch in channel_ids]
+        recordings = self._timeseries[channel_idxs, start_frame:end_frame]
         return recordings
 
     @staticmethod

--- a/spikeextractors/extractors/tridescloussortingextractor/tridescloussortingextractor.py
+++ b/spikeextractors/extractors/tridescloussortingextractor/tridescloussortingextractor.py
@@ -3,18 +3,18 @@ from pathlib import Path
 
 try:
     import tridesclous as tdc
+
     HAVE_TDC = True
 except ImportError:
     HAVE_TDC = False
 
 
 class TridesclousSortingExtractor(SortingExtractor):
-
     extractor_name = 'TridesclousSortingExtractor'
     installed = HAVE_TDC  # check at class level if installed or not
     is_writable = False
     mode = 'folder'
-    installation_mesg = "must install tridesclous" # error message when not installed
+    installation_mesg = "must install tridesclous"  # error message when not installed
 
     def __init__(self, folder_path, chan_grp=None):
         assert HAVE_TDC, "must install tridesclous"
@@ -29,13 +29,13 @@ class TridesclousSortingExtractor(SortingExtractor):
 
         self.chan_grp = chan_grp
         self.catalogue = self.dataio.load_catalogue(name='initial', chan_grp=chan_grp)
-        
+
         self._sampling_frequency = self.dataio.sample_rate
         self._kwargs = {'folder_path': str(Path(folder_path).absolute()), 'chan_grp': chan_grp}
 
     def get_unit_ids(self):
         labels = self.catalogue['clusters']['cluster_label']
-        labels = labels[labels>=0]
+        labels = labels[labels >= 0]
         return list(labels)
 
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
@@ -47,4 +47,4 @@ class TridesclousSortingExtractor(SortingExtractor):
             spike_times = spike_times[spike_times >= start_frame]
         if end_frame is not None:
             spike_times = spike_times[spike_times < end_frame]
-        return spike_times.copy()  #copy avoid reference to the unerlying memmap
+        return spike_times.copy()  # copy avoid reference to the unerlying memmap

--- a/spikeextractors/multirecordingchannelextractor.py
+++ b/spikeextractors/multirecordingchannelextractor.py
@@ -1,4 +1,5 @@
 from .recordingextractor import RecordingExtractor
+from .extraction_tools import check_get_traces_args
 import numpy as np
 
 # Concatenates the given recordings by channel
@@ -43,12 +44,8 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
                 raise ValueError("recordings and groups must have same length")
         self._kwargs = {'recordings': [rec.make_serialized_dict() for rec in recordings], 'groups': groups}
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
         traces = []
         if channel_ids is not None:
             for channel_id in channel_ids:

--- a/spikeextractors/multirecordingtimeextractor.py
+++ b/spikeextractors/multirecordingtimeextractor.py
@@ -1,4 +1,5 @@
 from .recordingextractor import RecordingExtractor
+from .extraction_tools import check_get_traces_args
 import numpy as np
 
 # Concatenates the given recordings by time
@@ -62,12 +63,8 @@ class MultiRecordingTimeExtractor(RecordingExtractor):
         ind = inds[-1]
         return self._recordings[ind], ind, time - self._start_times[ind]
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
         recording1, i_sec1, i_start_frame = self._find_section_for_frame(start_frame)
         _, i_sec2, i_end_frame = self._find_section_for_frame(end_frame)
         if i_sec1 == i_sec2:

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -5,7 +5,7 @@ import shutil
 import random
 from pathlib import Path
 from .extraction_tools import load_probe_file, save_to_probe_file, write_to_binary_dat_format, \
-    get_sub_extractors_by_property
+    get_sub_extractors_by_property, cast_start_end_frame
 from .baseextractor import BaseExtractor
 
 
@@ -521,7 +521,7 @@ class RecordingExtractor(ABC, BaseExtractor):
             recording after the start_frame.
         '''
         if isinstance(epoch_name, str):
-            start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
+            start_frame, end_frame = cast_start_end_frame(start_frame, end_frame)
             self._epochs[epoch_name] = {'start_frame': start_frame, 'end_frame': end_frame}
         else:
             raise TypeError("epoch_name must be a string")
@@ -797,19 +797,3 @@ class RecordingExtractor(ABC, BaseExtractor):
         '''
         raise NotImplementedError("The write_recording function is not \
                                   implemented for this extractor")
-
-
-    def _cast_start_end_frame(self, start_frame, end_frame):
-        if isinstance(start_frame, (float, np.float)):
-            start_frame = int(start_frame)
-        elif isinstance(start_frame, (int, np.integer, type(None))):
-            start_frame = start_frame
-        else:
-            raise ValueError("start_frame must be an int, float (not infinity), or None")
-        if isinstance(end_frame, (float, np.float)):
-            end_frame = int(end_frame)
-        elif isinstance(end_frame, (int, np.integer, type(None))):
-            end_frame = end_frame
-        else:
-            raise ValueError("end_frame must be an int, float (not infinity), or None")
-        return start_frame, end_frame

--- a/spikeextractors/subrecordingextractor.py
+++ b/spikeextractors/subrecordingextractor.py
@@ -1,4 +1,5 @@
 from .recordingextractor import RecordingExtractor
+from .extraction_tools import check_get_traces_args, cast_start_end_frame
 import numpy as np
 
 
@@ -9,7 +10,7 @@ class SubRecordingExtractor(RecordingExtractor):
 
     def __init__(self, parent_recording, *, channel_ids=None, renamed_channel_ids=None, start_frame=None,
                  end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
+        start_frame, end_frame = cast_start_end_frame(start_frame, end_frame)
         self._parent_recording = parent_recording
         self._channel_ids = channel_ids
         self._renamed_channel_ids = renamed_channel_ids
@@ -33,14 +34,8 @@ class SubRecordingExtractor(RecordingExtractor):
         self._kwargs = {'parent_recording': parent_recording.make_serialized_dict(), 'channel_ids': channel_ids,
                         'renamed_channel_ids': renamed_channel_ids, 'start_frame': start_frame, 'end_frame': end_frame}
 
+    @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
-        if channel_ids is None:
-            channel_ids = self.get_channel_ids()
         sf = self._start_frame + start_frame
         ef = self._start_frame + end_frame
         original_ch_ids = self.get_original_channel_ids(channel_ids)


### PR DESCRIPTION
@colehurwitz already added some checks for parsing start and end frame.
I suggest a decorator in the extractor tools that:
- checks `start_frame` and `end_frame`
- checks that all `channel_ids` are correct / filters out wrong ones
- parses to `start_frame` and `end_frame` 

Note that this can be accessed by `spiketoolkit` and could be extended in the future. It would cleanup a lot of the code and fix unwanted bugs (e.g. passing `start_frame` < 0 was not caught before o it needed to be done in each get_traces). 

The `@wraps` decorator makes sure that the docstrings is kept.
If you give me the green light I'll do some cleanup :)