### PR TITLE
Add `is_filtered` to BaseExtractor

### DIFF
--- a/spikeextractors/baseextractor.py
+++ b/spikeextractors/baseextractor.py
@@ -12,6 +12,7 @@ class BaseExtractor:
         self._kwargs = {}
         self._tmp_folder = None
         self.is_dumpable = True
+        self.is_filtered = False
 
     def make_serialized_dict(self):
         class_name = str(type(self)).replace("<class '", "").replace("'>", '')

--- a/spikeextractors/cacherecordingextractor.py
+++ b/spikeextractors/cacherecordingextractor.py
@@ -29,6 +29,7 @@ class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
         self._bindat_kwargs = deepcopy(self._kwargs)
         self.set_tmp_folder(tmp_folder)
         self.copy_channel_properties(recording)
+        self.is_filtered = self._recording.is_filtered
         self._kwargs = {'recording': recording, 'chunk_size': chunk_size}
 
     def __del__(self):

--- a/spikeextractors/example_datasets/toy_example.py
+++ b/spikeextractors/example_datasets/toy_example.py
@@ -19,4 +19,5 @@ def toy_example(duration=10, num_channels=4, sampling_frequency=30000.0, K=10, s
     SX.set_sampling_frequency(sampling_frequency)
 
     RX = se.NumpyRecordingExtractor(timeseries=X, sampling_frequency=sampling_frequency, geom=geom)
+    RX.is_filtered = True
     return (RX, SX)

--- a/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
@@ -26,6 +26,8 @@ class SpikeGLXRecordingExtractor(RecordingExtractor):
         self._basepath = self._npxfile.parents[0]
 
         # Gets file type: 'imec0.ap', 'imec0.lf' or 'nidq'
+        if 'ap' in str(self._npxfile):
+            self.is_filtered = True
         aux = self._npxfile.stem.split('.')[-1]
         if aux == 'nidq':
             self._ftype = aux

--- a/spikeextractors/version.py
+++ b/spikeextractors/version.py
@@ -1,1 +1,1 @@
-version = '0.7.4'
+version = '0.8.0'

--- a/spikeextractors/version.py
+++ b/spikeextractors/version.py
@@ -1,1 +1,1 @@
-version = '0.8.0'
+version = '0.7.4'


### PR DESCRIPTION
This makes it easy to know if a RecordingExtractor is filtered or not (especially for spiketoolkit)