### PR TITLE
Fixes to bindat, maxone, mea1k extractors

### DIFF
--- a/spikeextractors/cacherecordingextractor.py
+++ b/spikeextractors/cacherecordingextractor.py
@@ -43,6 +43,8 @@ class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
         save_path = Path(save_path)
         if save_path.suffix != '.dat' and save_path.suffix != '.bin':
             save_path = save_path.with_suffix('.dat')
+        if not save_path.parent.is_dir():
+            os.makedirs(save_path.parent)
         shutil.move(self._tmp_file, str(save_path))
         self._tmp_file = str(save_path)
         self._kwargs['file_path'] = str(Path(self._tmp_file).absolute())

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -247,13 +247,13 @@ def read_binary(file, numchan, dtype, time_axis=0, offset=0):
     numchan = int(numchan)
     with Path(file).open() as f:
         nsamples = (os.fstat(f.fileno()).st_size - offset) // (numchan * np.dtype(dtype).itemsize)
-        if time_axis == 0:
-            samples = np.memmap(f, np.dtype(dtype), mode='r', offset=offset,
-                                shape=(nsamples, numchan))
-            samples = np.memmap.transpose(samples)
-        else:
-            samples = np.memmap(f, np.dtype(dtype), mode='r', offset=offset,
-                                shape=(numchan, nsamples))
+    if time_axis == 0:
+        samples = np.memmap(file, np.dtype(dtype), mode='r', offset=offset,
+                            shape=(nsamples, numchan))
+        samples = np.memmap.transpose(samples)
+    else:
+        samples = np.memmap(file, np.dtype(dtype), mode='r', offset=offset,
+                            shape=(numchan, nsamples))
     return samples
 
 

--- a/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
+++ b/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
@@ -1,6 +1,7 @@
 from spikeextractors import RecordingExtractor
 from spikeextractors.extraction_tools import read_binary, write_to_binary_dat_format, check_get_traces_args
 import shutil
+import numpy as np
 from pathlib import Path
 
 
@@ -55,7 +56,8 @@ class BinDatRecordingExtractor(RecordingExtractor):
 
     @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        recordings = self._timeseries[:, start_frame:end_frame][channel_ids, :]
+        channel_idxs = np.array([self.get_channel_ids().index(ch) for ch in channel_ids])
+        recordings = self._timeseries[:, start_frame:end_frame][channel_idxs, :]
         if self._dtype.startswith('uint'):
             exp_idx = self._dtype.find('int') + 3
             exp = int(self._dtype[exp_idx:])
@@ -94,6 +96,7 @@ class BinDatRecordingExtractor(RecordingExtractor):
         else:
             write_to_binary_dat_format(self, save_path=save_path, time_axis=time_axis, dtype=dtype,
                                        chunk_size=chunk_size, chunk_mb=chunk_mb)
+
 
     @staticmethod
     def write_recording(recording, save_path, time_axis=0, dtype=None, chunk_size=None):

--- a/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
+++ b/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
@@ -3,6 +3,7 @@ from spikeextractors.extraction_tools import read_binary, write_to_binary_dat_fo
 import shutil
 import numpy as np
 from pathlib import Path
+import os
 
 
 class BinDatRecordingExtractor(RecordingExtractor):
@@ -19,10 +20,12 @@ class BinDatRecordingExtractor(RecordingExtractor):
         self._datfile = Path(file_path)
         self._time_axis = time_axis
         self._dtype = str(dtype)
-        self._timeseries = read_binary(self._datfile, numchan, dtype, time_axis, offset)
         self._sampling_frequency = float(sampling_frequency)
         self._gain = gain
+        self._numchan = numchan
         self._geom = geom
+        self._offset = offset
+        self._timeseries = read_binary(self._datfile, numchan, dtype, time_axis, offset)
 
         if recording_channels is not None:
             assert len(recording_channels) == self._timeseries.shape[0], \
@@ -43,7 +46,6 @@ class BinDatRecordingExtractor(RecordingExtractor):
         self._kwargs = {'file_path': str(Path(file_path).absolute()), 'sampling_frequency': sampling_frequency,
                         'numchan': numchan, 'dtype': dtype_str, 'recording_channels': recording_channels,
                         'time_axis': time_axis, 'geom': geom, 'offset': offset, 'gain': gain}
-
 
     def get_channel_ids(self):
         return self._channels

--- a/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
+++ b/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
@@ -58,14 +58,12 @@ class MaxOneRecordingExtractor(RecordingExtractor):
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         if np.array(channel_ids).size > 1:
             assert np.all([ch in self.get_channel_ids() for ch in channel_ids])
-            channel_idxs = [self.get_channel_ids().index(ch) for ch in channel_ids]
-            if np.any(np.diff(channel_idxs) < 0):
-                sorted_idx = np.argsort(channel_idxs)
-                recordings = self._signals[np.sort(channel_idxs), start_frame:end_frame]
+            if np.any(np.diff(channel_ids) < 0):
+                sorted_idx = np.argsort(channel_ids)
+                recordings = self._signals[np.sort(channel_ids), start_frame:end_frame]
                 return (recordings[sorted_idx] * self._lsb).astype('float')
             else:
-                return (self._signals[np.array(channel_idxs), start_frame:end_frame] * self._lsb).astype('float')
+                return (self._signals[np.array(channel_ids), start_frame:end_frame] * self._lsb).astype('float')
         else:
             assert channel_ids in self.get_channel_ids()
-            channel_idx = self.get_channel_ids().index(channel_ids)
-            return (self._signals[np.array(channel_idx), start_frame:end_frame] * self._lsb).astype('float')
+            return (self._signals[np.array(channel_ids), start_frame:end_frame] * self._lsb).astype('float')

--- a/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
+++ b/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
@@ -32,6 +32,7 @@ class MaxOneRecordingExtractor(RecordingExtractor):
     def _initialize(self):
         self._filehandle = h5py.File(self._file_path, 'r')
         self._mapping = self._filehandle['mapping']
+        self._lsb = self._filehandle['settings']['lsb'][()] * 1e6
         channels = np.array(self._mapping['channel'])
         electrodes = np.array(self._mapping['electrode'])
         # remove unused channels
@@ -61,10 +62,10 @@ class MaxOneRecordingExtractor(RecordingExtractor):
             if np.any(np.diff(channel_idxs) < 0):
                 sorted_idx = np.argsort(channel_idxs)
                 recordings = self._signals[np.sort(channel_idxs), start_frame:end_frame]
-                return recordings[sorted_idx]
+                return (recordings[sorted_idx] * self._lsb).astype('float')
             else:
-                return self._signals[np.array(channel_idxs), start_frame:end_frame]
+                return (self._signals[np.array(channel_idxs), start_frame:end_frame] * self._lsb).astype('float')
         else:
             assert channel_ids in self.get_channel_ids()
             channel_idx = self.get_channel_ids().index(channel_ids)
-            return self._signals[np.array(channel_idx), start_frame:end_frame]
+            return (self._signals[np.array(channel_idx), start_frame:end_frame] * self._lsb).astype('float')

--- a/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
+++ b/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
@@ -58,17 +58,15 @@ class Mea1kRecordingExtractor(RecordingExtractor):
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         if np.array(channel_ids).size > 1:
             assert np.all([ch in self.get_channel_ids() for ch in channel_ids])
-            channel_idxs = [self.get_channel_ids().index(ch) for ch in channel_ids]
-            if np.any(np.diff(channel_idxs) < 0):
-                sorted_idx = np.argsort(channel_idxs)
-                recordings = self._signals[np.sort(channel_idxs), start_frame:end_frame]
+            if np.any(np.diff(channel_ids) < 0):
+                sorted_idx = np.argsort(channel_ids)
+                recordings = self._signals[np.sort(channel_ids), start_frame:end_frame]
                 return recordings[sorted_idx].astype('float')
             else:
-                return self._signals[np.array(channel_idxs), start_frame:end_frame].astype('float')
+                return self._signals[np.array(channel_ids), start_frame:end_frame].astype('float')
         else:
             assert channel_ids in self.get_channel_ids()
-            channel_idx = self.get_channel_ids().index(channel_ids)
-            return self._signals[np.array(channel_idx), start_frame:end_frame].astype('float')
+            return self._signals[np.array(channel_ids), start_frame:end_frame].astype('float')
 
     @staticmethod
     def write_recording(recording, save_path):

--- a/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
+++ b/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
@@ -62,13 +62,13 @@ class Mea1kRecordingExtractor(RecordingExtractor):
             if np.any(np.diff(channel_idxs) < 0):
                 sorted_idx = np.argsort(channel_idxs)
                 recordings = self._signals[np.sort(channel_idxs), start_frame:end_frame]
-                return recordings[sorted_idx]
+                return recordings[sorted_idx].astype('float')
             else:
-                return self._signals[np.array(channel_idxs), start_frame:end_frame]
+                return self._signals[np.array(channel_idxs), start_frame:end_frame].astype('float')
         else:
             assert channel_ids in self.get_channel_ids()
             channel_idx = self.get_channel_ids().index(channel_ids)
-            return self._signals[np.array(channel_idx), start_frame:end_frame]
+            return self._signals[np.array(channel_idx), start_frame:end_frame].astype('float')
 
     @staticmethod
     def write_recording(recording, save_path):


### PR DESCRIPTION
- found a bad bug in the `read_binary` function, was affecting performance A LOT. Basically, the memmap file was open and closed within the function...

- fixed some indexing in MAxOne and Mea1k extractors

- Cache creates folder if non-existing