### PR TITLE
Refractor properties and features for dumping

### DIFF
--- a/spikeextractors/baseextractor.py
+++ b/spikeextractors/baseextractor.py
@@ -55,7 +55,7 @@ class BaseExtractor:
         '''
         return self.make_serialized_dict()
 
-    def dump_to_json(self, file_path=None, dump_properties_and_features=True):
+    def dump_to_json(self, file_path=None):
         '''
         Dumps recording extractor to json file.
         The extractor can be re-loaded with spikeextractors.load_extractor_from_json(json_file)
@@ -64,8 +64,6 @@ class BaseExtractor:
         ----------
         file_path: str
             Path of the json file
-        dump_properties_and_features: bool
-            If True, property and features are dumped as npz files in the same folder as the json
         '''
         if self.check_if_dumpable():
             if file_path is None:
@@ -95,8 +93,10 @@ class BaseExtractor:
         ----------
         file_path: str
             Path of the json file
-        dump_properties_and_features: bool
-            If True, property and features are dumped as npz files in the same folder as the json
+        include_properties: bool
+            If True, all properties are dumped
+        include_features: bool
+            If True, all features are dumped
         '''
         if self.check_if_dumpable():
             dump_dict = {}

--- a/spikeextractors/baseextractor.py
+++ b/spikeextractors/baseextractor.py
@@ -205,31 +205,6 @@ class BaseExtractor:
         from .extraction_tools import cast_start_end_frame
         return cast_start_end_frame(start_frame, end_frame)
 
-    def _include_properties_and_features_in_dict(self, dump_dict, include_properties, include_features):
-        if include_properties is not None:
-            assert isinstance(include_properties, list), "'include_properties' should be a list of property names"
-            dump_dict['properties'] = {}
-            dump_properties_dict = {}
-            for property in include_properties:
-                for key, props in self._properties.items():
-                    if property in props.keys():
-                        if key not in dump_properties_dict.keys():
-                            dump_properties_dict[key] = {}
-                        dump_properties_dict[key].update({property: props[property]})
-            if len(dump_properties_dict.keys()) > 1:
-                dump_dict['properties'] = dump_properties_dict
-        if include_features is not None:
-            assert isinstance(include_features, list), "'include_features' should be a list of feature names"
-            dump_features_dict = {}
-            for feature in include_features:
-                for key, feats in self._features.items():
-                    if feature in feats.keys():
-                        if key not in dump_features_dict.keys():
-                            dump_features_dict[key] = {}
-                        dump_features_dict[key].update({feature: feats[feature]})
-            if len(dump_features_dict.keys()) > 1:
-                dump_dict['features'] = dump_features_dict
-        return dump_dict
 
     @staticmethod
     def load_extractor_from_json(json_file):

--- a/spikeextractors/baseextractor.py
+++ b/spikeextractors/baseextractor.py
@@ -13,12 +13,13 @@ class BaseExtractor:
     def __init__(self):
         self._kwargs = {}
         self._tmp_folder = None
+        self._key_properties = {}
         self._properties = {}
         self._features = {}
         self.is_dumpable = True
         self.is_filtered = False
 
-    def make_serialized_dict(self, include_properties=None, include_features=None):
+    def make_serialized_dict(self):
         '''
         Makes a nested serialized dictionary out of the extractor. The dictionary be used to re-initialize an
         extractor with spikeextractors.load_extractor_from_dict(dump_dict)
@@ -27,10 +28,6 @@ class BaseExtractor:
         -------
         dump_dict: dict
             Serialized dictionary
-        include_properties: list or None
-            List of properties to include in the dictionary
-        include_features: list or None
-            List of features to include in the dictionary
         '''
         class_name = str(type(self)).replace("<class '", "").replace("'>", '')
         module = class_name.split('.')[0]
@@ -38,14 +35,27 @@ class BaseExtractor:
 
         if self.is_dumpable:
             dump_dict = {'class': class_name, 'module': module, 'kwargs': self._kwargs,
-                         'version': imported_module.__version__, 'dumpable': True}
+                         'key_properties': self._key_properties, 'version': imported_module.__version__,
+                         'dumpable': True}
         else:
-            dump_dict = {'class': class_name, 'module': module, 'kwargs': {},
+            dump_dict = {'class': class_name, 'module': module, 'kwargs': {}, 'key_properties': self._key_properties,
                          'version': imported_module.__version__, 'dumpable': False}
-        dump_dict = self._include_properties_and_features_in_dict(dump_dict, include_properties, include_features)
         return dump_dict
 
-    def dump(self, file_path=None, dump_properties_and_features=True):
+    def dump_to_dict(self):
+        '''
+        Dumps recording to a dictionary.
+        The dictionary be used to re-initialize an
+        extractor with spikeextractors.load_extractor_from_dict(dump_dict)
+
+        Returns
+        -------
+        dump_dict: dict
+            Serialized dictionary
+        '''
+        return self.make_serialized_dict()
+
+    def dump_to_json(self, file_path=None, dump_properties_and_features=True):
         '''
         Dumps recording extractor to json file.
         The extractor can be re-loaded with spikeextractors.load_extractor_from_json(json_file)
@@ -73,15 +83,49 @@ class BaseExtractor:
             dump_dict = self.make_serialized_dict()
             with open(str(file_path), 'w', encoding='utf8') as f:
                 json.dump(_check_json(dump_dict), f, indent=4)
-            if dump_properties_and_features:
-                if len(self._properties.keys()) > 0:
-                    with (folder_path / 'properties.pkl').open('wb') as f:
-                        pickle.dump(self._properties, f)
-                if len(self._features.keys()) > 0:
-                    with (folder_path / 'features.pkl').open('wb') as f:
-                        pickle.dump(self._features, f)
         else:
             raise Exception(f"The extractor is not dumpable to to json")
+
+    def dump_to_pickle(self, file_path=None, include_properties=True, include_features=True):
+        '''
+        Dumps recording extractor to a pickle file.
+        The extractor can be re-loaded with spikeextractors.load_extractor_from_json(json_file)
+
+        Parameters
+        ----------
+        file_path: str
+            Path of the json file
+        dump_properties_and_features: bool
+            If True, property and features are dumped as npz files in the same folder as the json
+        '''
+        if self.check_if_dumpable():
+            dump_dict = {}
+            if file_path is None:
+                if 'Recording' in self.__class__:
+                    file_path = 'spikeinterface_recording.pkl'
+                elif 'Sorting' in self.__class__:
+                    file_path = 'spikeinterface_sorting.pkl'
+            file_path = Path(file_path)
+            if not file_path.parent.is_dir():
+                os.makedirs(str(file_path.parent))
+            if Path(file_path).suffix == '':
+                file_path = file_path.parent / (str(file_path) + '.pkl')
+            assert file_path.suffix == '.pkl' or file_path.suffix == '.pickle', "'file_path' should be a .pkl or " \
+                                                                                ".pickle file"
+
+            # Dump all
+            dump_dict['serialized_dict'] = self.make_serialized_dict()
+            if include_properties:
+                if len(self._properties.keys()) > 0:
+                    dump_dict['properties'] = self._properties
+            if include_features:
+                if len(self._features.keys()) > 0:
+                    dump_dict['features'] = self._features
+
+            with file_path.open('wb') as f:
+                pickle.dump(dump_dict, f)
+        else:
+            raise Exception(f"The extractor is not dumpable to to pkl")
 
     def get_tmp_folder(self):
         '''
@@ -206,14 +250,31 @@ class BaseExtractor:
         with open(str(json_file), 'r') as f:
             d = json.load(f)
             extractor = _load_extractor_from_dict(d)
-        property_file = json_file.parent / 'properties.pkl'
-        features_file = json_file.parent / 'features.pkl'
-        if property_file.is_file():
-            with property_file.open('rb') as f:
-                extractor._properties = pickle.load(f)
-        if features_file.is_file():
-            with features_file.open('rb') as f:
-                extractor._features = pickle.load(f)
+        return extractor
+
+    @staticmethod
+    def load_extractor_from_pickle(pkl_file):
+        '''
+        Instantiates extractor from json file
+
+        Parameters
+        ----------
+        json_file: str or Path
+            Path to json file
+
+        Returns
+        -------
+        extractor: RecordingExtractor or SortingExtractor
+            The loaded extractor object
+        '''
+        pkl_file = Path(pkl_file)
+        with open(str(pkl_file), 'rb') as f:
+            d = pickle.load(f)
+        extractor = _load_extractor_from_dict(d['serialized_dict'])
+        if 'properties' in d.keys():
+            extractor._properties = d['properties']
+        if 'features' in d.keys():
+            extractor._features = d['features']
         return extractor
 
     @staticmethod
@@ -287,10 +348,8 @@ def _load_extractor_from_dict(dic):
         extractor = extractor.load_probe_file(probe_file=probe_file)
 
     # load properties and features
-    if 'properties' in dic.keys():
-        extractor._properties = dic['properties']
-    if 'features' in dic.keys():
-        extractor._features = dic['features']
+    if 'key_properties' in dic.keys():
+        extractor._key_properties = dic['key_properties']
 
     return extractor
 

--- a/spikeextractors/cacherecordingextractor.py
+++ b/spikeextractors/cacherecordingextractor.py
@@ -53,6 +53,9 @@ class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
         self._kwargs['file_path'] = str(Path(self._tmp_file).absolute())
         self._bindat_kwargs['file_path'] = str(Path(self._tmp_file).absolute())
         self._is_tmp = False
+        # re-initialize with new file
+        print('re-init')
+        self = BinDatRecordingExtractor(**self._bindat_kwargs)
 
     # override to make serialization avoid reloading and saving binary file
     def make_serialized_dict(self, include_properties=None, include_features=None):
@@ -79,7 +82,5 @@ class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
                   "function")
 
         dump_dict = {'class': class_name, 'module': module, 'kwargs': self._bindat_kwargs,
-                     'version': imported_module.__version__, 'dumpable': True}
-
-        dump_dict = self._include_properties_and_features_in_dict(dump_dict, include_properties, include_features)
+                     'key_properties': self._key_properties, 'version': imported_module.__version__, 'dumpable': True}
         return dump_dict

--- a/spikeextractors/cacherecordingextractor.py
+++ b/spikeextractors/cacherecordingextractor.py
@@ -55,7 +55,20 @@ class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
         self._is_tmp = False
 
     # override to make serialization avoid reloading and saving binary file
-    def make_serialized_dict(self):
+    def make_serialized_dict(self, include_properties=None, include_features=None):
+        '''
+        Makes a nested serialized dictionary out of the extractor. The dictionary be used to re-initialize an
+        extractor with spikeextractors.load_extractor_from_dict(dump_dict)
+
+        Returns
+        -------
+        dump_dict: dict
+            Serialized dictionary
+        include_properties: list or None
+            List of properties to include in the dictionary
+        include_features: list or None
+            List of features to include in the dictionary
+        '''
         class_name = str(BinDatRecordingExtractor).replace("<class '", "").replace("'>", '')
         module = class_name.split('.')[0]
         imported_module = importlib.import_module(module)
@@ -68,40 +81,5 @@ class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
         dump_dict = {'class': class_name, 'module': module, 'kwargs': self._bindat_kwargs,
                      'version': imported_module.__version__, 'dumpable': True}
 
-        if 'Recording' in class_name:
-            if 'group' in self.get_shared_channel_property_names():
-                groups = self.get_channel_groups()
-                dump_dict['groups'] = groups
-            if 'location' in self.get_shared_channel_property_names():
-                locations = self.get_channel_locations()
-                dump_dict['locations'] = locations
-        elif 'Sorting' in class_name:
-            if 'group' in self.get_shared_unit_property_names():
-                groups = [self.get_unit_property(u, 'group') for u in self.get_unit_ids()]
-                dump_dict['groups'] = groups
-
+        dump_dict = self._include_properties_and_features_in_dict(dump_dict, include_properties, include_features)
         return dump_dict
-
-    def dump(self, file_name=None, folder_path=None):
-        '''
-        Dumps recording extractor to json file.
-        The extractor can be re-loaded with spikeextractors.load_extractor_from_json(json_file)
-
-        Parameters
-        ----------
-        file_name: str
-            Filename
-        folder_path: str or Path
-            Path to output_folder
-        '''
-        if folder_path is None:
-            folder_path = Path(os.getcwd())
-        else:
-            folder_path = Path(folder_path)
-        if file_name is None:
-            file_name = 'spikeinterface_recording.json'
-        elif Path(file_name).suffix == '':
-            file_name = file_name + '.json'
-        dump_dict = self.make_serialized_dict()
-        with open(str(folder_path / file_name), 'w', encoding='utf8') as f:
-            json.dump(_check_json(dump_dict), f, indent=4)

--- a/spikeextractors/cacherecordingextractor.py
+++ b/spikeextractors/cacherecordingextractor.py
@@ -54,7 +54,6 @@ class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
         self._bindat_kwargs['file_path'] = str(Path(self._tmp_file).absolute())
         self._is_tmp = False
         # re-initialize with new file
-        print('re-init')
         self = BinDatRecordingExtractor(**self._bindat_kwargs)
 
     # override to make serialization avoid reloading and saving binary file

--- a/spikeextractors/example_datasets/__init__.py
+++ b/spikeextractors/example_datasets/__init__.py
@@ -1,1 +1,1 @@
-from .toy_example import toy_example, create_dumpable_extractors
+from .toy_example import toy_example

--- a/spikeextractors/example_datasets/toy_example.py
+++ b/spikeextractors/example_datasets/toy_example.py
@@ -6,7 +6,8 @@ from .synthesize_random_firings import synthesize_random_firings
 from .synthesize_timeseries import synthesize_timeseries
 
 
-def toy_example(duration=10, num_channels=4, sampling_frequency=30000.0, K=10, seed=None):
+def toy_example(duration=10, num_channels=4, sampling_frequency=30000.0, K=10, dumpable=False, dump_folder=None,
+                seed=None):
     upsamplefac = 13
 
     waveforms, geom = synthesize_random_waveforms(K=K, M=num_channels, average_peak_amplitude=-100,
@@ -15,24 +16,22 @@ def toy_example(duration=10, num_channels=4, sampling_frequency=30000.0, K=10, s
     labels = labels.astype(np.int64)
     SX = se.NumpySortingExtractor()
     SX.set_times_labels(times, labels)
-    X = synthesize_timeseries(sorting=SX, waveforms=waveforms, noise_level=10, sampling_frequency=sampling_frequency, duration=duration,
+    X = synthesize_timeseries(sorting=SX, waveforms=waveforms, noise_level=10, sampling_frequency=sampling_frequency,
+                              duration=duration,
                               waveform_upsamplefac=upsamplefac, seed=seed)
     SX.set_sampling_frequency(sampling_frequency)
 
     RX = se.NumpyRecordingExtractor(timeseries=X, sampling_frequency=sampling_frequency, geom=geom)
     RX.is_filtered = True
+
+    if dumpable:
+        if dump_folder is None:
+            dump_folder = 'toy_example'
+        dump_folder = Path(dump_folder)
+
+        se.MdaRecordingExtractor.write_recording(RX, dump_folder)
+        RX = se.MdaRecordingExtractor(dump_folder)
+        se.NpzSortingExtractor.write_sorting(SX, dump_folder / 'sorting.npz')
+        SX = se.NpzSortingExtractor(dump_folder / 'sorting.npz')
+
     return RX, SX
-
-
-def create_dumpable_extractors(folder, duration=10, num_channels=4, sampling_frequency=30000.0, K=10, seed=None):
-    RX, SX = toy_example(duration=duration, num_channels=num_channels, K=K, sampling_frequency=sampling_frequency,
-                         seed=seed)
-
-    folder = Path(folder)
-
-    se.MdaRecordingExtractor.write_recording(RX, folder)
-    RX_mda = se.MdaRecordingExtractor(folder)
-    se.NpzSortingExtractor.write_sorting(SX, folder / 'sorting.npz')
-    SX_npz = se.NpzSortingExtractor(folder / 'sorting.npz')
-
-    return RX_mda, SX_npz

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -108,14 +108,14 @@ def load_probe_file(recording, probe_file, channel_map=None, channel_groups=None
                     if key_prop == 'channels':
                         for i_ch, prop in enumerate(prop_val):
                             if prop in subrecording.get_channel_ids():
-                                subrecording.set_channel_property(prop, 'group', int(cgroup_id))
+                                subrecording.set_channel_groups(int(cgroup_id), channel_ids=prop)
                     elif key_prop == 'geometry' or key_prop == 'location':
                         if isinstance(prop_val, dict):
                             if len(prop_val.keys()) != channels_in_group and verbose:
                                 print('geometry in PRB does not have the same length as channel in group')
                             for (i_ch, prop) in prop_val.items():
                                 if i_ch in subrecording.get_channel_ids():
-                                    subrecording.set_channel_property(i_ch, 'location', prop)
+                                    subrecording.set_channel_locations(prop, channel_ids=i_ch)
                         elif isinstance(prop_val, (list, np.ndarray)) and len(prop_val) == channels_in_group:
                             if 'channels' not in cgroup.keys():
                                 raise Exception("'geometry'/'location' in the .prb file can be a list only if "
@@ -124,7 +124,7 @@ def load_probe_file(recording, probe_file, channel_map=None, channel_groups=None
                                 print('geometry in PRB does not have the same length as channel in group')
                             for (i_ch, prop) in zip(channels_id_in_group, prop_val):
                                 if i_ch in subrecording.get_channel_ids():
-                                    subrecording.set_channel_property(i_ch, 'location', prop)
+                                    subrecording.set_channel_locations(prop, channel_ids=i_ch)
                     else:
                         if isinstance(prop_val, dict) and len(prop_val.keys()) == channels_in_group:
                             for (i_ch, prop) in prop_val.items():
@@ -136,8 +136,9 @@ def load_probe_file(recording, probe_file, channel_map=None, channel_groups=None
                                     subrecording.set_channel_property(i_ch, key_prop, prop)
                 # create dummy locations
                 if 'geometry' not in cgroup.keys() and 'location' not in cgroup.keys():
-                    for i, chan in enumerate(subrecording.get_channel_ids()):
-                        subrecording.set_channel_property(chan, 'location', [0, i])
+                    locs = np.zeros((subrecording.get_num_channels(), 2))
+                    locs[:, 1] = np.arange(subrecording.get_num_channels())
+                    subrecording.set_channel_locations(locs)
         else:
             raise AttributeError("'.prb' file should contain the 'channel_groups' field")
 
@@ -159,11 +160,11 @@ def load_probe_file(recording, probe_file, channel_map=None, channel_groups=None
                                                                      "rows as the number of channels in the recordings"
             for i_ch, pos in zip(subrecording.get_channel_ids(), loaded_pos):
                 if i_ch in subrecording.get_channel_ids():
-                    subrecording.set_channel_property(i_ch, 'location', list(np.array(pos).astype(float)))
+                    subrecording.set_channel_locations(list(np.array(pos).astype(float)), i_ch)
             if channel_groups is not None and len(channel_groups) == len(subrecording.get_channel_ids()):
                 for i_ch, chg in zip(subrecording.get_channel_ids(), channel_groups):
                     if i_ch in subrecording.get_channel_ids():
-                        subrecording.set_channel_property(i_ch, 'group', chg)
+                        subrecording.set_channel_groups(chg, i_ch)
     else:
         raise NotImplementedError("Only .csv and .prb probe files can be loaded.")
 
@@ -202,7 +203,7 @@ def save_to_probe_file(recording, probe_file, grouping_property=None, radius=Non
         with probe_file.open('w') as f:
             if 'location' in recording.get_shared_channel_property_names():
                 for chan in recording.get_channel_ids():
-                    loc = recording.get_channel_property(chan, 'location')
+                    loc = recording.get_channel_locations(chan)
                     if len(loc) == 2:
                         f.write(str(loc[0]))
                         f.write(',')
@@ -432,8 +433,7 @@ def _export_prb_file(recording, file_name, grouping_property=None, graph=True, g
 
     if geometry:
         if 'location' in recording.get_shared_channel_property_names():
-            positions = np.array([recording.get_channel_property(chan, 'location')
-                                  for chan in recording.get_channel_ids()])
+            positions = recording.get_channel_locations()
         else:
             if verbose:
                 print("'location' property is not available and it will not be saved.")
@@ -563,6 +563,23 @@ def load_extractor_from_dict(d):
         The loaded extractor object
     '''
     return BaseExtractor.load_extractor_from_dict(d)
+
+
+def load_extractor_from_pickle(pkl_file):
+    '''
+    Instantiates extractor from pickle file
+
+    Parameters
+    ----------
+    pkl_file: str or Path
+        Path to json file
+
+    Returns
+    -------
+    extractor: RecordingExtractor or SortingExtractor
+        The loaded extractor object
+    '''
+    return BaseExtractor.load_extractor_from_pickle(pkl_file)
 
 
 def check_get_traces_args(func):

--- a/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
+++ b/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
@@ -41,8 +41,7 @@ class BinDatRecordingExtractor(RecordingExtractor):
             self._channels = list(range(self._timeseries.shape[0]))
 
         if geom is not None:
-            for idx, channel in enumerate(self._channels):
-                self.set_channel_property(channel, 'location', self._geom[idx, :])
+            self.set_channel_locations(self._geom)
         if 'numpy' in str(dtype):
             dtype_str = str(dtype).replace("<class '", "").replace("'>", "")
             # drop 'numpy

--- a/spikeextractors/extractors/biocamrecordingextractor/biocamrecordingextractor.py
+++ b/spikeextractors/extractors/biocamrecordingextractor/biocamrecordingextractor.py
@@ -28,8 +28,7 @@ class BiocamRecordingExtractor(RecordingExtractor):
         self._file_format, self._signalInv, self._positions, self._read_function = openBiocamFile(
             self._recording_file, self._mea_pitch, verbose)
         RecordingExtractor.__init__(self)
-        for m in range(self._nRecCh):
-            self.set_channel_property(m, 'location', self._positions[m])
+        self.set_channel_locations(self._positions)
 
         self._kwargs = {'file_path': str(Path(file_path).absolute()), 'mea_pitch': mea_pitch,
                         'verbose': verbose}
@@ -83,8 +82,8 @@ class BiocamRecordingExtractor(RecordingExtractor):
         rf.create_dataset('3BRecInfo/3BRecVars/SamplingRate', data=[recording.get_sampling_frequency()])
         rf.create_dataset('3BRecInfo/3BRecVars/SignalInversion', data=[1])
         rf.create_dataset('3BRecInfo/3BMeaChip/NCols', data=[M])
-        r = [recording.get_channel_property(i, 'location')[-2] for i in range(recording.get_num_channels())]
-        c = [recording.get_channel_property(i, 'location')[-1] for i in range(recording.get_num_channels())]
+        r = recording.get_channel_locations()[:, 0]
+        c = recording.get_channel_locations()[:, 1]
         d = np.ndarray((1, len(r)), dtype=[('Row', '<i2'), ('Col', '<i2')])
         d['Row'] = r
         d['Col'] = c

--- a/spikeextractors/extractors/hs2sortingextractor/hs2sortingextractor.py
+++ b/spikeextractors/extractors/hs2sortingextractor/hs2sortingextractor.py
@@ -4,9 +4,11 @@ from pathlib import Path
 
 try:
     import h5py
+
     HAVE_HS2SX = True
 except ImportError:
     HAVE_HS2SX = False
+
 
 class HS2SortingExtractor(SortingExtractor):
     extractor_name = 'HS2SortingExtractor'
@@ -36,25 +38,21 @@ class HS2SortingExtractor(SortingExtractor):
         self._kwargs = {'file_path': str(Path(file_path).absolute()), 'load_unit_info': load_unit_info}
 
     def load_unit_info(self):
-        if ('centres' in self._rf.keys()) and (len(self._times)>0):
+        if 'centres' in self._rf.keys() and len(self._times) > 0:
             self._unit_locs = self._rf['centres'][()]  # cache for faster access
             for u_i, unit_id in enumerate(self._unit_ids):
                 self.set_unit_property(unit_id, property_name='unit_location', value=self._unit_locs[u_i])
         inds = []  # get these only once
         for unit_id in self._unit_ids:
-            inds.append(np.where(self._cluster_id==unit_id)[0])
-        if ('data' in self._rf.keys()) and (len(self._times)>0):
+            inds.append(np.where(self._cluster_id == unit_id)[0])
+        if 'data' in self._rf.keys() and len(self._times) > 0:
             d = self._rf['data'][()]
             for i, unit_id in enumerate(self._unit_ids):
-                self._unit_features[unit_id] = {}
-                self._unit_features[unit_id]['spike_location'] = d[:, inds[i]].T
-        else:
-            for i, unit_id in enumerate(self._unit_ids):
-                self._unit_features[unit_id] = {}
-        if ('ch' in self._rf.keys()) and (len(self._times)>0):
+                self.set_unit_spike_features(unit_id, 'spike_location', d[:, inds[i]].T)
+        if 'ch' in self._rf.keys() and len(self._times) > 0:
             d = self._rf['ch'][()]
             for i, unit_id in enumerate(self._unit_ids):
-                self._unit_features[unit_id]['max_channel'] = d[inds[i]]
+                self.set_unit_spike_features(unit_id, 'max_channel', d[inds[i]])
 
     def get_unit_indices(self, x):
         return np.where(self._cluster_id == x)[0]
@@ -85,29 +83,30 @@ class HS2SortingExtractor(SortingExtractor):
             labels_list.append(np.ones(times.shape, dtype=int) * unit)
         all_times = np.concatenate(times_list)
         all_labels = np.concatenate(labels_list)
-        
+
         rf = h5py.File(save_path, mode='w')
         if sorting.get_sampling_frequency() is not None:
             rf.create_dataset("Sampling", data=sorting.get_sampling_frequency())
         else:
             rf.create_dataset("Sampling", data=0)
         if 'unit_location' in sorting.get_shared_unit_property_names():
-            spike_centres = [sorting.get_unit_property(u,'unit_location') for u in sorting.get_unit_ids()]
+            spike_centres = [sorting.get_unit_property(u, 'unit_location') for u in sorting.get_unit_ids()]
             spike_centres = np.array(spike_centres)
             rf.create_dataset("centres", data=spike_centres)
         if 'spike_location' in sorting.get_shared_unit_spike_feature_names():
             spike_loc_x = []
             spike_loc_y = []
             for u in sorting.get_unit_ids():
-                l = sorting.get_unit_spike_features(u,'spike_location')
-                spike_loc_x.append(l[:,0])
-                spike_loc_y.append(l[:,1])        
-            spike_loc = np.vstack((np.concatenate(spike_loc_x),np.concatenate(spike_loc_y)))
+                l = sorting.get_unit_spike_features(u, 'spike_location')
+                spike_loc_x.append(l[:, 0])
+                spike_loc_y.append(l[:, 1])
+            spike_loc = np.vstack((np.concatenate(spike_loc_x), np.concatenate(spike_loc_y)))
             rf.create_dataset("data", data=spike_loc)
         if 'max_channel' in sorting.get_shared_unit_spike_feature_names():
-            spike_max_channel = np.concatenate([sorting.get_unit_spike_features(u,'max_channel') for u in sorting.get_unit_ids()])
+            spike_max_channel = np.concatenate(
+                [sorting.get_unit_spike_features(u, 'max_channel') for u in sorting.get_unit_ids()])
             rf.create_dataset("ch", data=spike_max_channel)
-            
+
         rf.create_dataset("times", data=all_times)
         rf.create_dataset("cluster_id", data=all_labels)
         rf.close()

--- a/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
+++ b/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
@@ -43,7 +43,7 @@ class MaxOneRecordingExtractor(RecordingExtractor):
         self._num_frames = self._signals.shape[1]
 
         for i_ch, ch in enumerate(self.get_channel_ids()):
-            self.set_channel_property(ch, 'location', [self._mapping['x'][i_ch], self._mapping['y'][i_ch]])
+            self.set_channel_locations([self._mapping['x'][i_ch], self._mapping['y'][i_ch]], ch)
 
     def get_channel_ids(self):
         return list(self._channel_ids)

--- a/spikeextractors/extractors/mdaextractors/mdaextractors.py
+++ b/spikeextractors/extractors/mdaextractors/mdaextractors.py
@@ -36,8 +36,7 @@ class MdaRecordingExtractor(RecordingExtractor):
         self._num_channels = X.N1()
         self._num_timepoints = X.N2()
         RecordingExtractor.__init__(self)
-        for m in range(self._num_channels):
-            self.set_channel_property(m, 'location', self._geom[m, :])
+        self.set_channel_locations(self._geom)
         self._kwargs = {'folder_path': str(Path(folder_path).absolute())}
 
     def get_channel_ids(self):
@@ -128,12 +127,7 @@ class MdaRecordingExtractor(RecordingExtractor):
         num_chan = recording.get_num_channels()
         num_frames = recording.get_num_frames()
 
-        location0 = recording.get_channel_property(channel_ids[0], 'location')
-        nd = len(location0)
-        geom = np.zeros((num_chan, nd))
-        for ii in range(len(channel_ids)):
-            location_ii = recording.get_channel_property(channel_ids[ii], 'location')
-            geom[ii, :] = list(location_ii)
+        geom = recording.get_channel_locations()
 
         if not save_path.is_dir():
             os.mkdir(save_path)

--- a/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
+++ b/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
@@ -43,7 +43,7 @@ class Mea1kRecordingExtractor(RecordingExtractor):
         self._num_frames = self._signals.shape[1]
 
         for i_ch, ch in enumerate(self.get_channel_ids()):
-            self.set_channel_property(ch, 'location', [self._mapping['x'][i_ch], self._mapping['y'][i_ch]])
+            self.set_channel_locations([self._mapping['x'][i_ch], self._mapping['y'][i_ch]], ch)
 
     def get_channel_ids(self):
         return list(self._channel_ids)

--- a/spikeextractors/extractors/mearecextractors/mearecextractors.py
+++ b/spikeextractors/extractors/mearecextractors/mearecextractors.py
@@ -34,8 +34,7 @@ class MEArecRecordingExtractor(RecordingExtractor):
         RecordingExtractor.__init__(self)
 
         if self._locations is not None:
-            for chan, pos in enumerate(self._locations):
-                self.set_channel_property(chan, 'location', pos)
+            self.set_channel_locations(self._locations)
 
         self._kwargs = {'file_path': str(Path(file_path).absolute()), 'locs_2d': locs_2d}
 
@@ -102,8 +101,7 @@ class MEArecRecordingExtractor(RecordingExtractor):
             info = {'recordings': {'fs': recording.get_sampling_frequency()}}
             rec_dict = {'recordings': recording.get_traces()}
             if 'location' in recording.get_shared_channel_property_names():
-                positions = np.array([recording.get_channel_property(chan, 'location')
-                                      for chan in recording.get_channel_ids()])
+                positions = recording.get_channel_locations()
                 rec_dict['channel_positions'] = positions
             recgen = mr.RecordingGenerator(rec_dict=rec_dict, info=info)
             mr.save_recording_generator(recgen, str(save_path), verbose=False)

--- a/spikeextractors/extractors/numpyextractors/numpyextractors.py
+++ b/spikeextractors/extractors/numpyextractors/numpyextractors.py
@@ -35,8 +35,7 @@ class NumpyRecordingExtractor(RecordingExtractor):
         self._sampling_frequency = float(sampling_frequency)
         self._geom = geom
         if geom is not None:
-            for m in range(self._timeseries.shape[0]):
-                self.set_channel_property(m, 'location', self._geom[m, :])
+            self.set_channel_locations(self._geom)
 
     def get_channel_ids(self):
         return list(range(self._timeseries.shape[0]))

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -354,17 +354,9 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         channel_ids = recording.get_channel_ids()
         for m in channel_ids:
             if m not in nwb_elec_ids:
-                if 'location' in recording.get_channel_property_names(m):
-                    location = recording.get_channel_property(m, 'location')
-                    while len(location) < 2:
-                        location = np.append(location, [0])
-                else:
-                    location = [np.nan, np.nan]
-                if 'group' in recording.get_channel_property_names(m):
-                    grp_name = recording.get_channel_groups(channel_ids=[m])
-                    grp = nwbfile.electrode_groups[nwb_groups_names[grp_name[0]]]
-                else:
-                    grp = nwbfile.electrode_groups[nwb_groups_names[0]]
+                location = recording.get_channel_locations(channel_ids=m)
+                grp_name = recording.get_channel_groups(channel_ids=m)
+                grp = nwbfile.electrode_groups[nwb_groups_names[grp_name]]
                 impedance = -1.0
                 nwbfile.add_electrode(
                     id=m,

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -633,11 +633,11 @@ class NwbSortingExtractor(se.SortingExtractor):
                 if item + '_index' in all_names:  # if it has index, it is a spike_feature
                     for id in units_ids:
                         ind = list(units_ids).index(id)
-                        self._unit_features.update({id: {item: nwbfile.units[item][ind]}})
+                        self.set_unit_spike_features(id, item, nwbfile.units[item][ind])
                 else:  # if it is unit_property
                     for id in units_ids:
                         ind = list(units_ids).index(id)
-                        self._unit_properties.update({id: {item: nwbfile.units[item][ind]}})
+                        self.set_unit_property(id, item, nwbfile.units[item][ind])
 
             # Fill epochs dictionary
             self._epochs = {}
@@ -705,8 +705,8 @@ class NwbSortingExtractor(se.SortingExtractor):
             t0 = 0.
 
         (all_properties, all_features) = find_all_unit_property_names(
-            properties_dict=sorting._unit_properties,
-            features_dict=sorting._unit_features
+            properties_dict=sorting._properties,
+            features_dict=sorting._features
         )
 
         if os.path.exists(save_path):
@@ -732,9 +732,9 @@ class NwbSortingExtractor(se.SortingExtractor):
 
             # Units properties
             for pr in all_properties:
-                unit_ids = [int(k) for k, v in sorting._unit_properties.items()
+                unit_ids = [int(k) for k, v in sorting._properties.items()
                             if pr in v]
-                vals = [v[pr] for k, v in sorting._unit_properties.items()
+                vals = [v[pr] for k, v in sorting._properties.items()
                         if pr in v]
                 set_dynamic_table_property(
                     dynamic_table=nwbfile.units,
@@ -765,7 +765,7 @@ class NwbSortingExtractor(se.SortingExtractor):
             nspikes = {k: get_nspikes(nwbfile.units, int(k)) for k in ids}
             for ft in all_features:
                 vals = [v[ft] if ft in v else [np.nan] * nspikes[int(k)]
-                        for k, v in sorting._unit_features.items()]
+                        for k, v in sorting._features.items()]
                 flatten_vals = [item for sublist in vals for item in sublist]
                 nspks_list = [sp for sp in nspikes.values()]
                 spikes_index = np.cumsum(nspks_list).tolist()

--- a/spikeextractors/extractors/phyextractors/phyextractors.py
+++ b/spikeextractors/extractors/phyextractors/phyextractors.py
@@ -37,14 +37,12 @@ class PhyRecordingExtractor(BinDatRecordingExtractor):
         if (phy_folder / 'channel_groups.npy').is_file():
             channel_groups = np.load(phy_folder / 'channel_groups.npy')
             assert len(channel_groups) == self.get_num_channels()
-            for (ch, cg) in zip(self.get_channel_ids(), channel_groups):
-                self.set_channel_property(ch, 'group', cg)
+            self.set_channel_groups(channel_groups)
 
         if (phy_folder / 'channel_positions.npy').is_file():
             channel_locations = np.load(phy_folder / 'channel_positions.npy')
             assert len(channel_locations) == self.get_num_channels()
-            for (ch, loc) in zip(self.get_channel_ids(), channel_locations):
-                self.set_channel_property(ch, 'location', loc)
+            self.set_channel_locations(channel_locations)
 
         self._kwargs = {'folder_path': str(Path(folder_path).absolute())}
 
@@ -159,8 +157,7 @@ class PhySortingExtractor(SortingExtractor):
             if (phy_folder / 'channel_groups.npy').is_file():
                 channel_groups = np.load(phy_folder / 'channel_groups.npy')
                 assert len(channel_groups) == recording.get_num_channels()
-                for (ch, cg) in zip(recording.get_channel_ids(), channel_groups):
-                    recording.set_channel_property(ch, 'group', cg)
+                recording.set_channel_groups(channel_groups)
                 for u_i, u in enumerate(self.get_unit_ids()):
                     if verbose:
                         print('Computing waveform by group for unit', u)
@@ -176,7 +173,7 @@ class PhySortingExtractor(SortingExtractor):
                         wf = recording.get_snippets(reference_frames=spiketrain,
                                                     snippet_len=[frames_before, frames_after])
                         max_chan = np.unravel_index(np.argmin(np.mean(wf, axis=0)), np.mean(wf, axis=0).shape)[0]
-                        group = recording.get_channel_property(int(max_chan), 'group')
+                        group = recording.get_channel_groups(int(max_chan))
                         self.set_unit_property(u, 'group', group)
                         group_idx = np.where(channel_groups == group)[0]
                         wf = wf[:, group_idx]

--- a/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
@@ -49,8 +49,7 @@ class SpikeGLXRecordingExtractor(RecordingExtractor):
 
         # locations
         if len(locations) > 0:
-           for m in range(len(self._channels)):
-               self.set_channel_property(m, 'location', locations[m])
+            self.set_channel_locations(locations)
 
         # get gains
         if meta['typeThis'] == 'imec':

--- a/spikeextractors/multirecordingchannelextractor.py
+++ b/spikeextractors/multirecordingchannelextractor.py
@@ -39,7 +39,7 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
                 for i, group in enumerate(groups):
                     recording = recordings[i]                    
                     channel_ids = recording.get_channel_ids()
-                    recording.set_channel_groups(channel_ids=channel_ids, groups=np.repeat(group,len(channel_ids)))
+                    recording.set_channel_groups(groups=np.repeat(group, len(channel_ids)), channel_ids=channel_ids)
             else:
                 raise ValueError("recordings and groups must have same length")
         self._kwargs = {'recordings': [rec.make_serialized_dict() for rec in recordings], 'groups': groups}

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -18,7 +18,6 @@ class RecordingExtractor(ABC, BaseExtractor):
     def __init__(self):
         BaseExtractor.__init__(self)
         self._epochs = {}
-        self._channel_properties = {}
         self.id = random.randint(a=0, b=9223372036854775807)
 
     def __del__(self):
@@ -366,10 +365,10 @@ class RecordingExtractor(ABC, BaseExtractor):
         '''
         if isinstance(channel_id, (int, np.integer)):
             if channel_id in self.get_channel_ids():
-                if channel_id not in self._channel_properties:
-                    self._channel_properties[channel_id] = {}
+                if channel_id not in self._properties.keys():
+                    self._properties[channel_id] = {}
                 if isinstance(property_name, str):
-                    self._channel_properties[channel_id][property_name] = value
+                    self._properties[channel_id][property_name] = value
                 else:
                     raise TypeError(str(property_name) + " must be a string")
             else:
@@ -398,13 +397,13 @@ class RecordingExtractor(ABC, BaseExtractor):
             raise TypeError(str(channel_id) + " must be an int")
         if channel_id not in self.get_channel_ids():
             raise ValueError(str(channel_id) + " is not a valid channel_id")
-        if channel_id not in self._channel_properties:
+        if channel_id not in self._properties.keys():
             raise ValueError('no properties found for channel' + str(channel_id))
-        if property_name not in self._channel_properties[channel_id]:
+        if property_name not in self._properties[channel_id]:
             raise RuntimeError(str(property_name) + " has not been added to channel " + str(channel_id))
         if not isinstance(property_name, str):
             raise TypeError(str(property_name) + " must be a string")
-        return self._channel_properties[channel_id][property_name]
+        return self._properties[channel_id][property_name]
 
     def get_channel_property_names(self, channel_id):
         '''Get a list of property names for a given channel.
@@ -420,9 +419,9 @@ class RecordingExtractor(ABC, BaseExtractor):
         '''
         if isinstance(channel_id, (int, np.integer)):
             if channel_id in self.get_channel_ids():
-                if channel_id not in self._channel_properties:
-                    self._channel_properties[channel_id] = {}
-                property_names = sorted(self._channel_properties[channel_id].keys())
+                if channel_id not in self._properties.keys():
+                    self._properties[channel_id] = {}
+                property_names = sorted(self._properties[channel_id].keys())
                 return property_names
             else:
                 raise ValueError(str(channel_id) + " is not a valid channel_id")
@@ -443,7 +442,6 @@ class RecordingExtractor(ABC, BaseExtractor):
         '''
         if channel_ids is None:
             channel_ids = self.get_channel_ids()
-        property_names = []
         curr_property_name_set = set(self.get_channel_property_names(channel_id=channel_ids[0]))
         for channel_id in channel_ids[1:]:
             curr_channel_property_name_set = set(self.get_channel_property_names(channel_id=channel_id))
@@ -486,9 +484,9 @@ class RecordingExtractor(ABC, BaseExtractor):
         property_name: string
             The name of the property to be cleared
         '''
-        if channel_id in self._channel_properties:
-            if property_name in self._channel_properties[channel_id]:
-                del self._channel_properties[channel_id][property_name]
+        if channel_id in self._properties.keys():
+            if property_name in self._properties[channel_id]:
+                del self._properties[channel_id][property_name]
 
     def clear_channels_property(self, property_name, channel_ids=None):
         '''This function clears the channels' properties for the given property.

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -226,7 +226,7 @@ class RecordingExtractor(ABC, BaseExtractor):
             self._key_properties['location'] = np.empty((self.get_num_channels(), 3), dtype='float')
         if len(channel_ids) == len(locations):
             for i in range(len(channel_ids)):
-                if isinstance(locations[i], (list, np.ndarray)):
+                if isinstance(locations[i], (list, np.ndarray, tuple)):
                     location = np.asarray(locations[i])
                     channel_idx = list(self.get_channel_ids()).index(channel_ids[i])
                     if len(location) == 2:
@@ -264,10 +264,12 @@ class RecordingExtractor(ABC, BaseExtractor):
         locations = self._key_properties['location']
         if locations is None:
             locations = np.empty((self.get_num_channels(), 3), dtype='float')
+            locations[:, 2] = np.nan
             self._key_properties['location'] = locations
+        locations = np.array(locations)
         channel_idxs = np.array([list(self.get_channel_ids()).index(ch) for ch in channel_ids])
         if locations_2d:
-            locations = locations[:, :2]
+            locations = np.array(locations)[:, :2]
         if len(channel_idxs) == 1:
             return locations[channel_idxs][0]
         else:
@@ -325,6 +327,7 @@ class RecordingExtractor(ABC, BaseExtractor):
         if groups is None:
             groups = np.zeros(self.get_num_channels(), dtype='int')
             self._key_properties['group'] = groups
+        groups = np.array(groups)
         channel_idxs = np.array([list(self.get_channel_ids()).index(ch) for ch in channel_ids])
         if len(channel_idxs) == 1:
             return groups[channel_idxs][0]

--- a/spikeextractors/sortingextractor.py
+++ b/spikeextractors/sortingextractor.py
@@ -143,8 +143,8 @@ class SortingExtractor(ABC, BaseExtractor):
                             raise ValueError("feature values should have the same length as the spike train")
                 else:
                     if isinstance(feature_name, str) and len(value) == len(indexes):
-                        self._unit_features[unit_id][feature_name] = value
-                        self._unit_features[unit_id][feature_name + '_idxs'] = np.array(indexes)
+                        self._features[unit_id][feature_name] = value
+                        self._features[unit_id][feature_name + '_idxs'] = np.array(indexes)
                     else:
                         if not isinstance(feature_name, str):
                             raise ValueError("feature_name must be a string")
@@ -225,10 +225,10 @@ class SortingExtractor(ABC, BaseExtractor):
                             else:
                                 raise ValueError(str(feature_name) + " dimensions are inconsistent for unit "
                                                  + str(unit_id))
-                            if isinstance(self._unit_features[unit_id][feature_name], list):
-                                return list(np.array(self._unit_features[unit_id][feature_name])[spike_indices])
+                            if isinstance(self._features[unit_id][feature_name], list):
+                                return list(np.array(self._features[unit_id][feature_name])[spike_indices])
                             else:
-                                return np.array(self._unit_features[unit_id][feature_name])[spike_indices]
+                                return np.array(self._features[unit_id][feature_name])[spike_indices]
                     else:
                         raise ValueError(str(feature_name) + " has not been added to unit " + str(unit_id))
                 else:

--- a/spikeextractors/tests/test_extractors.py
+++ b/spikeextractors/tests/test_extractors.py
@@ -47,7 +47,7 @@ class TestExtractors(unittest.TestCase):
         SX2.add_unit(unit_id=5, times=np.random.RandomState(seed=seed).uniform(0, num_frames, spike_times2[2]))
         SX2.set_unit_property(unit_id=4, property_name='stability', value=80)
         SX2.set_unit_spike_features(unit_id=3, feature_name='widths', value=np.asarray([3] * spike_times2[0]))
-        RX.set_channel_property(channel_id=0, property_name='location', value=(0, 0))
+        RX.set_channel_locations([0, 0], channel_ids=0)
         for i, unit_id in enumerate(SX2.get_unit_ids()):
             SX2.set_unit_property(unit_id=unit_id, property_name='shared_unit_prop', value=i)
             SX2.set_unit_spike_features(unit_id=unit_id, feature_name='shared_unit_feature',
@@ -86,14 +86,14 @@ class TestExtractors(unittest.TestCase):
         self.assertEqual(self.RX.get_num_frames(), self.example_info['num_frames'])
         self.assertEqual(self.RX.get_sampling_frequency(), self.example_info['sampling_frequency'])
         self.assertEqual(self.SX.get_unit_ids(), self.example_info['unit_ids'])
-        self.assertEqual(self.RX.get_channel_property(channel_id=0, property_name='location'),
-                         self.example_info['channel_prop'])
+        self.assertEqual(self.RX.get_channel_locations(0)[0], self.example_info['channel_prop'][0])
+        self.assertEqual(self.RX.get_channel_locations(0)[1], self.example_info['channel_prop'][1])
         self.assertEqual(self.SX.get_unit_property(unit_id=1, property_name='stability'),
                          self.example_info['unit_prop'])
         self.assertTrue(np.array_equal(self.SX.get_unit_spike_train(1), self.example_info['train1']))
         self.assertTrue(issubclass(self.SX.get_unit_spike_train(1).dtype.type, np.integer))
-        self.assertTrue(self.RX.get_shared_channel_property_names(), ['shared_channel_prop'])
-        self.assertTrue(self.RX.get_channel_property_names(0), ['location', 'shared_channel_prop'])
+        self.assertTrue(self.RX.get_shared_channel_property_names(), ['group', 'location', 'shared_channel_prop'])
+        self.assertTrue(self.RX.get_channel_property_names(0), ['group', 'location', 'shared_channel_prop'])
         self.assertTrue(self.SX2.get_shared_unit_property_names(), ['shared_unit_prop'])
         self.assertTrue(self.SX2.get_unit_property_names(4), ['shared_unit_prop', 'stability'])
         self.assertTrue(self.SX2.get_shared_unit_spike_feature_names(), ['shared_unit_feature'])
@@ -257,7 +257,7 @@ class TestExtractors(unittest.TestCase):
         print(RX_multi.get_channel_groups())
         RX_sub = se.SubRecordingExtractor(RX_multi, channel_ids=[4, 5, 6, 7], renamed_channel_ids=[0, 1, 2, 3])
         check_recordings_equal(self.RX2, RX_sub)
-        self.assertEqual([2, 2, 2, 2], RX_sub.get_channel_groups())
+        self.assertEqual([2, 2, 2, 2], list(RX_sub.get_channel_groups()))
         self.assertEqual(12, len(RX_multi.get_channel_ids()))
 
     def test_multi_sub_sorting_extractor(self):

--- a/spikeextractors/tests/test_numpy_extractors.py
+++ b/spikeextractors/tests/test_numpy_extractors.py
@@ -39,7 +39,7 @@ class TestNumpyExtractors(unittest.TestCase):
         self.assertTrue(
             np.allclose(self.RX.get_traces(channel_ids=[0, 3], start_frame=0, end_frame=12), self._X[[0, 3], 0:12]))
         # get_channel_property - location
-        self.assertTrue(np.allclose(np.array(self.RX.get_channel_property(1, 'location')), self._geom[1, :]))
+        self.assertTrue(np.allclose(np.array(self.RX.get_channel_locations(1)), self._geom[1, :]))
         # time_to_frame / frame_to_time
         self.assertEqual(self.RX.time_to_frame(12), 12 * self.RX.get_sampling_frequency())
         self.assertEqual(self.RX.frame_to_time(12), 12 / self.RX.get_sampling_frequency())

--- a/spikeextractors/tests/test_tools.py
+++ b/spikeextractors/tests/test_tools.py
@@ -1,6 +1,7 @@
 import numpy as np
 import unittest
-import tempfile, shutil
+import tempfile
+import shutil
 import spikeextractors as se
 from copy import copy
 from pathlib import Path
@@ -16,6 +17,7 @@ class TestTools(unittest.TestCase):
         self._X = X
         self._sampling_frequency = sampling_frequency
         self.RX = se.NumpyRecordingExtractor(timeseries=X, sampling_frequency=sampling_frequency)
+        self.RX.set_channel_locations(np.random.randn(32, 3))
         self.test_dir = tempfile.mkdtemp()
 
     def tearDown(self):
@@ -26,12 +28,12 @@ class TestTools(unittest.TestCase):
         # print(SX.get_channel_property_names())
         assert 'location' in sub_RX.get_shared_channel_property_names()
         assert 'group' in sub_RX.get_shared_channel_property_names()
-        positions = [sub_RX.get_channel_property(chan, 'location') for chan in range(self.RX.get_num_channels())]
+        positions = [sub_RX.get_channel_locations(chan) for chan in range(self.RX.get_num_channels())]
         # save in csv
         sub_RX.save_to_probe_file(Path(self.test_dir) / 'geom.csv')
         # load csv locations
         sub_RX_load = sub_RX.load_probe_file(Path(self.test_dir) / 'geom.csv')
-        position_loaded = [sub_RX_load.get_channel_property(chan, 'location') for
+        position_loaded = [sub_RX_load.get_channel_locations(chan) for
                            chan in range(sub_RX_load.get_num_channels())]
         self.assertTrue(np.allclose(positions[10], position_loaded[10]))
 

--- a/spikeextractors/tests/utils.py
+++ b/spikeextractors/tests/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 import shutil
-from spikeextractors.extraction_tools import load_extractor_from_json
+from spikeextractors.extraction_tools import load_extractor_from_pickle
 
 
 def check_recordings_equal(RX1, RX2):
@@ -77,8 +77,8 @@ def check_sorting_properties_features(SX1, SX2):
 
 
 def check_dumping(extractor):
-    extractor.dump(file_path='test_dumping/test.json', dump_properties_and_features=True)
-    extractor_loaded = load_extractor_from_json('test_dumping/test.json')
+    extractor.dump_to_pickle(file_path='test_dumping/test.pickle')
+    extractor_loaded = load_extractor_from_pickle('test_dumping/test.pickle')
 
     if 'Recording' in str(type(extractor)):
         check_recordings_equal(extractor, extractor_loaded)

--- a/spikeextractors/tests/utils.py
+++ b/spikeextractors/tests/utils.py
@@ -61,7 +61,7 @@ def check_sortings_equal(SX1, SX2):
 
 
 def check_dumping(extractor):
-    extractor.dump(file_name='test.json')
+    extractor.dump(file_path='test.json')
     extractor_loaded = load_extractor_from_json('test.json')
 
     if 'Recording' in str(type(extractor)):

--- a/spikeextractors/tests/utils.py
+++ b/spikeextractors/tests/utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import shutil
 from spikeextractors.extraction_tools import load_extractor_from_json
 
 
@@ -28,8 +29,13 @@ def check_recordings_equal(RX1, RX2):
     snippets2 = RX2.get_snippets(reference_frames=frames, snippet_len=(10, 10))
     for ii in range(len(frames)):
         assert np.allclose(snippets1[ii], snippets2[ii])
-        
-        
+
+
+def check_recording_properties(RX1, RX2):
+    # check properties
+    assert sorted(RX1.get_shared_channel_property_names()) == sorted(RX2.get_shared_channel_property_names())
+
+
 def check_recording_return_types(RX):
     channel_ids = RX.get_channel_ids()
     assert (type(RX.get_num_channels()) == int) or (type(RX.get_num_channels()) == np.int64)
@@ -60,11 +66,24 @@ def check_sortings_equal(SX1, SX2):
         assert np.array_equal(train1, train2)
 
 
+def check_sorting_properties_features(SX1, SX2):
+    # check properties
+    print(SX1.__class__)
+    print('Properties', sorted(SX1.get_shared_unit_property_names()), sorted(SX2.get_shared_unit_property_names()))
+    assert sorted(SX1.get_shared_unit_property_names()) == sorted(SX2.get_shared_unit_property_names())
+    # check features
+    print('Features', sorted(SX1.get_shared_unit_spike_feature_names()), sorted(SX2.get_shared_unit_spike_feature_names()))
+    assert sorted(SX1.get_shared_unit_spike_feature_names()) == sorted(SX2.get_shared_unit_spike_feature_names())
+
+
 def check_dumping(extractor):
-    extractor.dump(file_path='test.json')
-    extractor_loaded = load_extractor_from_json('test.json')
+    extractor.dump(file_path='test_dumping/test.json', dump_properties_and_features=True)
+    extractor_loaded = load_extractor_from_json('test_dumping/test.json')
 
     if 'Recording' in str(type(extractor)):
         check_recordings_equal(extractor, extractor_loaded)
+        check_recording_properties(extractor, extractor_loaded)
     elif 'Sorting' in str(type(extractor)):
         check_sortings_equal(extractor, extractor_loaded)
+        check_sorting_properties_features(extractor, extractor_loaded)
+    shutil.rmtree('test_dumping')


### PR DESCRIPTION
Final dumps! I think this is super important to save the status of recording and sortings (e.g. after extracting waveforms, pca, etc...)

- Added the consept of `key_properties` that for RecordingExtractors are `group` and `location`

- This cleans up property and feature handling, now done at the base class (`self._properties` and `self._features`).

- `make_serialized_dict()` allows saves `key_properties` by default

- 3 dump functions: `dump_to_dict`, `dump_to_json` (both save key properties) and `dump_to_pickle`, that enable saving all features and properties

- The `load_extractor_from_dict` and `load_extractor_from_json` have been modified to load the properties and features and the `load_extractor_from_pickle` has been added