### PR TITLE
new decorator for checking unit id validity

### DIFF
--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -575,14 +575,13 @@ def check_valid_unit_id(func):
         else:
             sorting = args[0]
             unit_id = args[1]
-            
         if unit_id is None:
             raise TypeError("get_unit_spike_train() missing 1 required positional argument: 'unit_id')")
+        elif not (isinstance(unit_id, (int, np.integer))):
+            raise ValueError("unit_id must be an integer")
         elif unit_id not in sorting.get_unit_ids():
             raise ValueError("{} is an invalid unit id".format(unit_id))
-
         return func(*args, **kwargs)
-
     return check_validity
 
 def check_get_traces_args(func):

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -570,16 +570,12 @@ def check_valid_unit_id(func):
     def check_validity(*args, **kwargs):
         # parse args and kwargs
         if len(args) == 1:
-            sorting = args[0]
-            unit_id = kwargs.get('unit_id', None)
+            raise TypeError("get_unit_spike_train() missing 1 required positional argument: 'unit_id')")
         else:
             sorting = args[0]
             unit_id = args[1]
-        
-
-        if unit_id is None:
-            raise TypeError("get_unit_spike_train() missing 1 required positional argument: 'unit_id')")
-        elif unit_id not in sorting.get_unit_ids():
+ 
+        if unit_id not in sorting.get_unit_ids():
             raise ValueError("{} is an invalid unit id".format(unit_id))
 
         return func(*args, **kwargs)

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -580,9 +580,10 @@ def check_valid_unit_id(func):
         elif not (isinstance(unit_id, (int, np.integer))):
             raise ValueError("unit_id must be an integer")
         elif unit_id not in sorting.get_unit_ids():
-            raise ValueError("{} is an invalid unit id".format(unit_id))
+            raise ValueError(f"{unit_id} is an invalid unit id")
         return func(*args, **kwargs)
     return check_validity
+
 
 def check_get_traces_args(func):
     @wraps(func)

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -570,12 +570,15 @@ def check_valid_unit_id(func):
     def check_validity(*args, **kwargs):
         # parse args and kwargs
         if len(args) == 1:
-            raise TypeError("get_unit_spike_train() missing 1 required positional argument: 'unit_id')")
+            sorting = args[0]
+            unit_id = kwargs.get('unit_id', None)
         else:
             sorting = args[0]
             unit_id = args[1]
- 
-        if unit_id not in sorting.get_unit_ids():
+            
+        if unit_id is None:
+            raise TypeError("get_unit_spike_train() missing 1 required positional argument: 'unit_id')")
+        elif unit_id not in sorting.get_unit_ids():
             raise ValueError("{} is an invalid unit id".format(unit_id))
 
         return func(*args, **kwargs)

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -565,6 +565,27 @@ def load_extractor_from_dict(d):
     return BaseExtractor.load_extractor_from_dict(d)
 
 
+def check_valid_unit_id(func):
+    @wraps(func)
+    def check_validity(*args, **kwargs):
+        # parse args and kwargs
+        if len(args) == 1:
+            sorting = args[0]
+            unit_id = kwargs.get('unit_id', None)
+        else:
+            sorting = args[0]
+            unit_id = args[1]
+        
+
+        if unit_id is None:
+            raise TypeError("get_unit_spike_train() missing 1 required positional argument: 'unit_id')")
+        elif unit_id not in sorting.get_unit_ids():
+            raise ValueError("{} is an invalid unit id".format(unit_id))
+
+        return func(*args, **kwargs)
+
+    return check_validity
+
 def check_get_traces_args(func):
     @wraps(func)
     def corrected_args(*args, **kwargs):

--- a/spikeextractors/extractors/exdirextractors/exdirextractors.py
+++ b/spikeextractors/extractors/exdirextractors/exdirextractors.py
@@ -3,7 +3,7 @@ from spikeextractors import SortingExtractor
 import numpy as np
 from pathlib import Path
 from copy import copy
-from spikeextractors.extraction_tools import check_get_traces_args
+from spikeextractors.extraction_tools import check_get_traces_args, check_valid_unit_id
 
 
 try:
@@ -261,6 +261,7 @@ class ExdirSortingExtractor(SortingExtractor):
     def get_unit_ids(self):
         return self._unit_ids
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:

--- a/spikeextractors/extractors/hs2sortingextractor/hs2sortingextractor.py
+++ b/spikeextractors/extractors/hs2sortingextractor/hs2sortingextractor.py
@@ -1,6 +1,7 @@
 from spikeextractors import SortingExtractor
 import numpy as np
 from pathlib import Path
+from spikeextractors.extraction_tools import check_valid_unit_id
 
 try:
     import h5py
@@ -62,6 +63,7 @@ class HS2SortingExtractor(SortingExtractor):
     def get_unit_ids(self):
         return list(self._unit_ids)
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:

--- a/spikeextractors/extractors/klustaextractors/klustaextractors.py
+++ b/spikeextractors/extractors/klustaextractors/klustaextractors.py
@@ -11,7 +11,7 @@ https://github.com/kwikteam/phy-doc/blob/master/docs/kwik-model.md
 
 from spikeextractors import SortingExtractor
 from spikeextractors.extractors.bindatrecordingextractor import BinDatRecordingExtractor
-from spikeextractors.extraction_tools import read_python
+from spikeextractors.extraction_tools import read_python, check_valid_unit_id
 import numpy as np
 from pathlib import Path
 
@@ -141,6 +141,7 @@ class KlustaSortingExtractor(SortingExtractor):
     def get_unit_ids(self):
         return list(self._unit_ids)
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:

--- a/spikeextractors/extractors/mdaextractors/mdaextractors.py
+++ b/spikeextractors/extractors/mdaextractors/mdaextractors.py
@@ -1,6 +1,6 @@
 from spikeextractors import RecordingExtractor
 from spikeextractors import SortingExtractor
-from spikeextractors.extraction_tools import write_to_binary_dat_format, check_get_traces_args
+from spikeextractors.extraction_tools import write_to_binary_dat_format, check_get_traces_args, check_valid_unit_id
 
 import json
 import numpy as np
@@ -185,6 +185,7 @@ class MdaSortingExtractor(SortingExtractor):
     def get_unit_ids(self):
         return list(self._unit_ids)
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:

--- a/spikeextractors/extractors/mearecextractors/mearecextractors.py
+++ b/spikeextractors/extractors/mearecextractors/mearecextractors.py
@@ -1,6 +1,6 @@
 from spikeextractors import RecordingExtractor
 from spikeextractors import SortingExtractor
-from spikeextractors.extraction_tools import check_get_traces_args
+from spikeextractors.extraction_tools import check_get_traces_args, check_valid_unit_id
 
 import numpy as np
 from pathlib import Path
@@ -155,6 +155,7 @@ class MEArecSortingExtractor(SortingExtractor):
             self._initialize()
         return self._num_units
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:

--- a/spikeextractors/extractors/neoextractors/neobaseextractor.py
+++ b/spikeextractors/extractors/neoextractors/neobaseextractor.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from spikeextractors import RecordingExtractor
 from spikeextractors import SortingExtractor
-from spikeextractors.extraction_tools import check_get_traces_args
+from spikeextractors.extraction_tools import check_get_traces_args, check_valid_unit_id
 
 try:
     import neo
@@ -152,6 +152,7 @@ class NeoBaseSortingExtractor(SortingExtractor, _NeoBaseExtractor):
         unit_ids = np.arange(self.neo_reader.header['unit_channels'].size, dtype='int64')
         return unit_ids
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         # this is a string

--- a/spikeextractors/extractors/neuroscopesortingextractor/neuroscopesortingextractor.py
+++ b/spikeextractors/extractors/neuroscopesortingextractor/neuroscopesortingextractor.py
@@ -1,6 +1,7 @@
 from spikeextractors import SortingExtractor
 import numpy as np
 from pathlib import Path
+from spikeextractors.extraction_tools import check_valid_unit_id
 
 
 class NeuroscopeSortingExtractor(SortingExtractor):
@@ -46,6 +47,7 @@ class NeuroscopeSortingExtractor(SortingExtractor):
     def get_unit_ids(self):
         return list(self._unit_ids)
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:

--- a/spikeextractors/extractors/nixioextractors/nixioextractors.py
+++ b/spikeextractors/extractors/nixioextractors/nixioextractors.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from spikeextractors import RecordingExtractor
 from spikeextractors import SortingExtractor
-from spikeextractors.extraction_tools import check_get_traces_args
+from spikeextractors.extraction_tools import check_get_traces_args, check_valid_unit_id
 
 # error message when not installed
 missing_nixio_msg = ("To use the NIXIORecordingExtractor install nixio:"
@@ -168,6 +168,7 @@ class NIXIOSortingExtractor(SortingExtractor):
     def get_unit_ids(self):
         return [int(da.label) for da in self._spike_das]
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         name = "spikes-{}".format(unit_id)

--- a/spikeextractors/extractors/npzsortingextractor/npzsortingextractor.py
+++ b/spikeextractors/extractors/npzsortingextractor/npzsortingextractor.py
@@ -1,6 +1,6 @@
 from spikeextractors import SortingExtractor
 from pathlib import Path
-
+from spikeextractors.extraction_tools import check_valid_unit_id
 import numpy as np
 
 
@@ -39,6 +39,7 @@ class NpzSortingExtractor(SortingExtractor):
     def get_unit_ids(self):
         return list(self.unit_ids)
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         spike_times = self.spike_indexes[self.spike_labels == unit_id]

--- a/spikeextractors/extractors/numpyextractors/numpyextractors.py
+++ b/spikeextractors/extractors/numpyextractors/numpyextractors.py
@@ -2,7 +2,8 @@ from spikeextractors import RecordingExtractor
 from spikeextractors import SortingExtractor
 from pathlib import Path
 import numpy as np
-from spikeextractors.extraction_tools import check_get_traces_args
+from functools import wraps
+from spikeextractors.extraction_tools import check_get_traces_args, check_valid_unit_id
 
 '''
 The NumpyExtractors can be constructed and used to encapsulate custom file formats and data structures which
@@ -93,7 +94,7 @@ class NumpySortingExtractor(SortingExtractor):
         self._sampling_frequency = sampling_frequency
 
     def set_times_labels(self, times, labels):
-        '''This function takes in an array of spike times (in frames) and an array of spike labels and adds all the 
+        '''This function takes in an array of spike times (in frames) and an array of spike labels and adds all the
         unit information in these lists into the extractor.
 
         Parameters
@@ -123,6 +124,7 @@ class NumpySortingExtractor(SortingExtractor):
     def get_unit_ids(self):
         return list(self._units.keys())
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 
 import spikeextractors as se
-from spikeextractors.extraction_tools import check_get_traces_args
+from spikeextractors.extraction_tools import check_get_traces_args, check_valid_unit_id
 
 try:
     import pynwb
@@ -664,6 +664,7 @@ class NwbSortingExtractor(se.SortingExtractor):
             unit_ids = [int(i) for i in nwbfile.units.id[:]]
         return unit_ids
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:

--- a/spikeextractors/extractors/openephysextractors/openephysextractors.py
+++ b/spikeextractors/extractors/openephysextractors/openephysextractors.py
@@ -1,7 +1,7 @@
 from spikeextractors import RecordingExtractor, SortingExtractor
 from pathlib import Path
 import numpy as np
-from spikeextractors.extraction_tools import check_get_traces_args
+from spikeextractors.extraction_tools import check_get_traces_args, check_valid_unit_id
 
 try:
     import pyopenephys
@@ -69,6 +69,7 @@ class OpenEphysSortingExtractor(SortingExtractor):
     def get_unit_ids(self):
         return self._unit_ids
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:

--- a/spikeextractors/extractors/phyextractors/phyextractors.py
+++ b/spikeextractors/extractors/phyextractors/phyextractors.py
@@ -1,6 +1,6 @@
 from spikeextractors import SortingExtractor, RecordingExtractor
 from spikeextractors.extractors.bindatrecordingextractor import BinDatRecordingExtractor
-from spikeextractors.extraction_tools import read_python, write_python
+from spikeextractors.extraction_tools import read_python, write_python, check_valid_unit_id
 import numpy as np
 from pathlib import Path
 import csv
@@ -198,6 +198,7 @@ class PhySortingExtractor(SortingExtractor):
     def get_unit_ids(self):
         return list(self._unit_ids)
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:

--- a/spikeextractors/extractors/shybridextractors/shybridextractors.py
+++ b/spikeextractors/extractors/shybridextractors/shybridextractors.py
@@ -1,10 +1,9 @@
 import os
 from pathlib import Path
 import numpy as np
-
 from spikeextractors import SortingExtractor
 from spikeextractors.extractors.bindatrecordingextractor import BinDatRecordingExtractor
-from spikeextractors.extraction_tools import save_to_probe_file, load_probe_file
+from spikeextractors.extraction_tools import save_to_probe_file, load_probe_file, check_valid_unit_id
 
 try:
     import hybridizer.io as sbio
@@ -117,6 +116,7 @@ class SHYBRIDSortingExtractor(SortingExtractor):
     def get_unit_ids(self):
         return self._spike_clusters.keys()
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         train = self._spike_clusters[unit_id].get_actual_spike_train().spikes

--- a/spikeextractors/extractors/spykingcircusextractors/spykingcircusextractors.py
+++ b/spikeextractors/extractors/spykingcircusextractors/spykingcircusextractors.py
@@ -2,6 +2,7 @@ from spikeextractors import SortingExtractor
 from spikeextractors.extractors.numpyextractors import NumpyRecordingExtractor
 import numpy as np
 from pathlib import Path
+from spikeextractors.extraction_tools import check_valid_unit_id
 
 try:
     import h5py
@@ -112,6 +113,7 @@ class SpykingCircusSortingExtractor(SortingExtractor):
     def get_unit_ids(self):
         return list(self._unit_ids)
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:

--- a/spikeextractors/extractors/tridescloussortingextractor/tridescloussortingextractor.py
+++ b/spikeextractors/extractors/tridescloussortingextractor/tridescloussortingextractor.py
@@ -1,5 +1,6 @@
 from spikeextractors import SortingExtractor
 from pathlib import Path
+from spikeextractors.extraction_tools import check_valid_unit_id
 
 try:
     import tridesclous as tdc
@@ -38,6 +39,7 @@ class TridesclousSortingExtractor(SortingExtractor):
         labels = labels[labels >= 0]
         return list(labels)
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         spikes = self.dataio.get_spikes(seg_num=0, chan_grp=self.chan_grp, i_start=None, i_stop=None)

--- a/spikeextractors/multisortingextractor.py
+++ b/spikeextractors/multisortingextractor.py
@@ -1,6 +1,7 @@
 from .sortingextractor import SortingExtractor
 from .recordingextractor import RecordingExtractor
 import numpy as np
+from .extraction_tools import check_valid_unit_id
 
 
 # Encapsulates a grouping of non-continuous sorting extractors
@@ -24,11 +25,9 @@ class MultiSortingExtractor(SortingExtractor):
     def get_unit_ids(self):
         return list(self._all_unit_ids)
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        if unit_id not in self.get_unit_ids():
-            raise ValueError("Non-valid unit_id")
-
         sorting_id = self._unit_map[unit_id]['sorting_id']
         unit_id_sorting = self._unit_map[unit_id]['unit_id']
         return self._sortings[sorting_id].get_unit_spike_train(unit_id_sorting, start_frame, end_frame)

--- a/spikeextractors/subsortingextractor.py
+++ b/spikeextractors/subsortingextractor.py
@@ -41,10 +41,7 @@ class SubSortingExtractor(SortingExtractor):
             start_frame = 0
         if end_frame is None:
             end_frame = np.Inf
-        if (isinstance(unit_id, (int, np.integer))):
-            original_unit_id = self._original_unit_id_lookup[unit_id]
-        else:
-            raise ValueError("unit_id must be an int")
+        original_unit_id = self._original_unit_id_lookup[unit_id]
         sf = self._start_frame + start_frame
         ef = self._start_frame + end_frame
         if sf < self._start_frame:

--- a/spikeextractors/subsortingextractor.py
+++ b/spikeextractors/subsortingextractor.py
@@ -1,5 +1,6 @@
 from .sortingextractor import SortingExtractor
 import numpy as np
+from .extraction_tools import check_valid_unit_id
 
 
 # Encapsulates a subset of a spike sorted data file
@@ -33,6 +34,7 @@ class SubSortingExtractor(SortingExtractor):
     def get_unit_ids(self):
         return list(self._renamed_unit_ids)
 
+    @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:
@@ -40,10 +42,7 @@ class SubSortingExtractor(SortingExtractor):
         if end_frame is None:
             end_frame = np.Inf
         if (isinstance(unit_id, (int, np.integer))):
-            if (unit_id in self.get_unit_ids()):
-                original_unit_id = self._original_unit_id_lookup[unit_id]
-            else:
-                raise ValueError("Non-valid unit_id")
+            original_unit_id = self._original_unit_id_lookup[unit_id]
         else:
             raise ValueError("unit_id must be an int")
         sf = self._start_frame + start_frame


### PR DESCRIPTION
Invalid unit_ids was throwing a key_error that was hard to understand. 

I made a decorator for all the `get_unit_spike_train` functions so that they check the validity of the unit_id beforehand (similar to the get_traces decorator that @alejoe91 made, but less complex).