### PR TITLE
BF: do not assume in __del__ that ._tmp_folder is available

### DIFF
--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -22,7 +22,7 @@ class RecordingExtractor(ABC, BaseExtractor):
         self.id = random.randint(a=0, b=9223372036854775807)
 
     def __del__(self):
-        if self._tmp_folder is not None:
+        if getattr(self, '_tmp_folder', None):
             try:
                 shutil.rmtree(self._tmp_folder)
             except Exception as e:


### PR DESCRIPTION
For a variety of reasons, one of which is that it is typical with python3 to arrive
to `__del__` whenever other attributes were freed already.  It is a bigger issue I am
not going to solve here, rather just to prevent a non interformative crash