### PR TITLE
RF+BF: centralize logic for handling dumping extractors into files

### DIFF
--- a/spikeextractors/exceptions.py
+++ b/spikeextractors/exceptions.py
@@ -1,0 +1,2 @@
+class NotDumpableExtractorError(TypeError):
+    """Raised whenever current extractor cannot be dumped"""

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -15,6 +15,9 @@ class RecordingExtractor(ABC, BaseExtractor):
     functions with the @abstractmethod tag must be implemented for the
     initialization to work.
     '''
+
+    _default_filename = "spikeinterface_recording"
+
     def __init__(self):
         BaseExtractor.__init__(self)
         self._key_properties = {'group': None, 'location': None}

--- a/spikeextractors/sortingextractor.py
+++ b/spikeextractors/sortingextractor.py
@@ -14,9 +14,10 @@ class SortingExtractor(ABC, BaseExtractor):
     from spiked sorted data given a spike sorting software. It is an abstract
     class so all functions with the @abstractmethod tag must be implemented for
     the initialization to work.
-
-
     '''
+
+    _default_filename = "spikeinterface_sorting"
+
     def __init__(self):
         BaseExtractor.__init__(self)
         self._epochs = {}


### PR DESCRIPTION
- avoid if/elif matching based on the class name (which might
  not even have those terms) and would rely on class inheritance to decide
  on default filename.

- avoid code duplication by concentrating it in _get_file_path which would
  do all necessary steps uniformly regardless or which them method invokes it.

- raises a dedicated NotDumpableExtractorError now instead of too generic
  Exception if for some reason current instance is not dumpable.

An alternative to #370 .  Completely alternatively, may be dumping to some default filename should be completely refactored out - IMHO better be explicit than implicit ;) (Zen of Python IIRC)

TODOs:
- [ ] a dedicated unittest which verifies storing into a default file path and that this new dedicated exception is raised

I have not approached the test since forgot good basic `unittest` with too much of the nose and pytest.  I see that pytest is used as a running on travis but not really used to compose the tests.  That is why, I would appreciate if someone takes over to finalize this PR (if you like it)