### PR TITLE
remove multiple return type

### DIFF
--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -203,7 +203,7 @@ def save_to_probe_file(recording, probe_file, grouping_property=None, radius=Non
         with probe_file.open('w') as f:
             if 'location' in recording.get_shared_channel_property_names():
                 for chan in recording.get_channel_ids():
-                    loc = recording.get_channel_locations(chan)
+                    loc = recording.get_channel_locations(chan)[0]
                     if len(loc) == 2:
                         f.write(str(loc[0]))
                         f.write(',')

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -354,8 +354,8 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         channel_ids = recording.get_channel_ids()
         for m in channel_ids:
             if m not in nwb_elec_ids:
-                location = recording.get_channel_locations(channel_ids=m)
-                grp_name = recording.get_channel_groups(channel_ids=m)
+                location = recording.get_channel_locations(channel_ids=m)[0]
+                grp_name = recording.get_channel_groups(channel_ids=m)[0]
                 grp = nwbfile.electrode_groups[nwb_groups_names[grp_name]]
                 impedance = -1.0
                 nwbfile.add_electrode(

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -273,10 +273,7 @@ class RecordingExtractor(ABC, BaseExtractor):
         channel_idxs = np.array([list(self.get_channel_ids()).index(ch) for ch in channel_ids])
         if locations_2d:
             locations = np.array(locations)[:, :2]
-        if len(channel_idxs) == 1:
-            return locations[channel_idxs][0]
-        else:
-            return locations[channel_idxs]
+        return locations[channel_idxs]
 
     def set_channel_groups(self, groups, channel_ids=None):
         '''This function sets the group property of each specified channel
@@ -332,10 +329,7 @@ class RecordingExtractor(ABC, BaseExtractor):
             self._key_properties['group'] = groups
         groups = np.array(groups)
         channel_idxs = np.array([list(self.get_channel_ids()).index(ch) for ch in channel_ids])
-        if len(channel_idxs) == 1:
-            return groups[channel_idxs][0]
-        else:
-            return groups[channel_idxs]
+        return groups[channel_idxs]
 
     def set_channel_gains(self, channel_ids, gains):
         '''This function sets the gain property of each specified channel

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -430,7 +430,7 @@ class RecordingExtractor(ABC, BaseExtractor):
             formats as specified by the user
         '''
         if property_name in self._key_properties.keys():
-            return eval(f"self.get_channel_{property_name}s")(channel_id)
+            return eval(f"self.get_channel_{property_name}s")(channel_id)[0]
         if not isinstance(channel_id, (int, np.integer)):
             raise TypeError(str(channel_id) + " must be an int")
         if channel_id not in self.get_channel_ids():

--- a/spikeextractors/tests/test_extractors.py
+++ b/spikeextractors/tests/test_extractors.py
@@ -87,8 +87,8 @@ class TestExtractors(unittest.TestCase):
         self.assertEqual(self.RX.get_num_frames(), self.example_info['num_frames'])
         self.assertEqual(self.RX.get_sampling_frequency(), self.example_info['sampling_frequency'])
         self.assertEqual(self.SX.get_unit_ids(), self.example_info['unit_ids'])
-        self.assertEqual(self.RX.get_channel_locations(0)[0], self.example_info['channel_prop'][0])
-        self.assertEqual(self.RX.get_channel_locations(0)[1], self.example_info['channel_prop'][1])
+        self.assertEqual(self.RX.get_channel_locations(0)[0][0], self.example_info['channel_prop'][0])
+        self.assertEqual(self.RX.get_channel_locations(0)[0][1], self.example_info['channel_prop'][1])
         self.assertEqual(self.SX.get_unit_property(unit_id=1, property_name='stability'),
                          self.example_info['unit_prop'])
         self.assertTrue(np.array_equal(self.SX.get_unit_spike_train(1), self.example_info['train1']))

--- a/spikeextractors/tests/test_tools.py
+++ b/spikeextractors/tests/test_tools.py
@@ -28,12 +28,12 @@ class TestTools(unittest.TestCase):
         # print(SX.get_channel_property_names())
         assert 'location' in sub_RX.get_shared_channel_property_names()
         assert 'group' in sub_RX.get_shared_channel_property_names()
-        positions = [sub_RX.get_channel_locations(chan) for chan in range(self.RX.get_num_channels())]
+        positions = [sub_RX.get_channel_locations(chan)[0] for chan in range(self.RX.get_num_channels())]
         # save in csv
         sub_RX.save_to_probe_file(Path(self.test_dir) / 'geom.csv')
         # load csv locations
         sub_RX_load = sub_RX.load_probe_file(Path(self.test_dir) / 'geom.csv')
-        position_loaded = [sub_RX_load.get_channel_locations(chan) for
+        position_loaded = [sub_RX_load.get_channel_locations(chan)[0] for
                            chan in range(sub_RX_load.get_num_channels())]
         self.assertTrue(np.allclose(positions[10], position_loaded[10]))
 


### PR DESCRIPTION
@alejoe91 I really think we should not be returning different types (int or list) for any function. I just caught a bug in SpikeInterface where it was expecting a list and got an int. We always will need `if` statements everywhere if we do this to deal with ints or lists. We removed this in epochs as well. 