### PR TITLE
use read mode when opening nwb file

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -147,7 +147,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         check_nwb_install()
         se.RecordingExtractor.__init__(self)
         self._path = file_path
-        with NWBHDF5IO(self._path, 'a') as io:
+        with NWBHDF5IO(self._path, 'r') as io:
             nwbfile = io.read()
             if electrical_series_name is not None:
                 self._electrical_series_name = electrical_series_name


### PR DESCRIPTION
Is there a reason that nwb files were opened using 'a' (append) mode? It's causing a problem for me because it updates the create time of the file every time it is opened.