### PR TITLE
fix read geom file for single channel

### DIFF
--- a/spikeextractors/extractors/mdaextractors/mdaextractors.py
+++ b/spikeextractors/extractors/mdaextractors/mdaextractors.py
@@ -27,7 +27,7 @@ class MdaRecordingExtractor(RecordingExtractor):
         self._timeseries_path = os.path.abspath(timeseries0)
         geom0 = dataset_directory / geom_fname
         self._geom_fname = geom0
-        self._geom = np.genfromtxt(self._geom_fname, delimiter=',')
+        self._geom = np.loadtxt(self._geom_fname, delimiter=',',ndmin=2)
         X = DiskReadMda(self._timeseries_path)
         if self._geom.shape[0] != X.N1():
             raise Exception(


### PR DESCRIPTION
I had to change the function to read the geometry file. 
 
A few lines after loading the file the number of channels on the recording is compared to self._geom.shape[0], but np.genfromtxt read a single line file as a vector of shape [2,] then it looks like the geom describes a 2 channel recording. 

The documentations say that loadtxt is equivalent to genfromtxt.