### PR TITLE
Speed up retrieval for bindat when channel ids are not given

### DIFF
--- a/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
+++ b/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
@@ -64,8 +64,11 @@ class BinDatRecordingExtractor(RecordingExtractor):
 
     @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        channel_idxs = np.array([self.get_channel_ids().index(ch) for ch in channel_ids])
-        recordings = self._timeseries[:, start_frame:end_frame][channel_idxs, :]
+        if np.all(channel_ids == self.get_channel_ids()):
+            recordings = self._timeseries[:, start_frame:end_frame]
+        else:
+            channel_idxs = np.array([self.get_channel_ids().index(ch) for ch in channel_ids])
+            recordings = self._timeseries[:, start_frame:end_frame][channel_idxs, :]
         if self._dtype.startswith('uint'):
             exp_idx = self._dtype.find('int') + 3
             exp = int(self._dtype[exp_idx:])

--- a/spikeextractors/tests/utils.py
+++ b/spikeextractors/tests/utils.py
@@ -62,7 +62,7 @@ def check_recording_return_types(RX):
     assert (type(RX.get_num_channels()) == int) or (type(RX.get_num_channels()) == np.int64)
     assert (type(RX.get_num_frames()) == int) or (type(RX.get_num_frames()) == np.int64)
     assert (type(RX.get_sampling_frequency()) == float) or (type(RX.get_sampling_frequency()) == np.float64)
-    assert type(RX.get_traces(start_frame=0, end_frame=10)) == np.ndarray
+    assert type(RX.get_traces(start_frame=0, end_frame=10)) in (np.ndarray, np.memmap)
     for channel_id in channel_ids:
         assert isinstance(channel_id, (int, np.integer))
 


### PR DESCRIPTION
In channel ids are note given, memmap is returned. 