### PR TITLE
Preload all spike once. This avoid memmap lock on the folde.

### DIFF
--- a/spikeextractors/extractors/tridescloussortingextractor/tridescloussortingextractor.py
+++ b/spikeextractors/extractors/tridescloussortingextractor/tridescloussortingextractor.py
@@ -21,32 +21,38 @@ class TridesclousSortingExtractor(SortingExtractor):
         assert HAVE_TDC, self.installation_mesg
         tdc_folder = Path(folder_path)
         SortingExtractor.__init__(self)
-        self.dataio = tdc.DataIO(str(tdc_folder))
+        
+        dataio = tdc.DataIO(str(tdc_folder))
         if chan_grp is None:
             # if chan_grp is not provided, take the first one if unique
-            chan_grps = list(self.dataio.channel_groups.keys())
-            assert len(chan_grps) == 1, 'There are several in the folder chan_grp, specify it'
+            chan_grps = list(dataio.channel_groups.keys())
+            assert len(chan_grps) == 1, 'There are several groups in the folder, specify chan_grp=...'
             chan_grp = chan_grps[0]
 
         self.chan_grp = chan_grp
-        self.catalogue = self.dataio.load_catalogue(name='initial', chan_grp=chan_grp)
-
-        self._sampling_frequency = self.dataio.sample_rate
+        
+        catalogue = dataio.load_catalogue(name='initial', chan_grp=chan_grp)
+        
+        labels = catalogue['clusters']['cluster_label']
+        labels = labels[labels >= 0]
+        self._unit_ids = list(labels)
+        # load all spike in memory (this avoid to lock the folder with memmap throug dataio
+        self._all_spikes = dataio.get_spikes(seg_num=0, chan_grp=self.chan_grp, i_start=None, i_stop=None).copy()
+    
+        self._sampling_frequency = dataio.sample_rate
         self._kwargs = {'folder_path': str(Path(folder_path).absolute()), 'chan_grp': chan_grp}
 
     def get_unit_ids(self):
-        labels = self.catalogue['clusters']['cluster_label']
-        labels = labels[labels >= 0]
-        return list(labels)
+        return self._unit_ids
 
     @check_valid_unit_id
     def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
-        spikes = self.dataio.get_spikes(seg_num=0, chan_grp=self.chan_grp, i_start=None, i_stop=None)
+        spikes = self._all_spikes
         spikes = spikes[spikes['cluster_label'] == unit_id]
         spike_times = spikes['index']
         if start_frame is not None:
             spike_times = spike_times[spike_times >= start_frame]
         if end_frame is not None:
             spike_times = spike_times[spike_times < end_frame]
-        return spike_times.copy()  # copy avoid reference to the unerlying memmap
+        return spike_times.copy()


### PR DESCRIPTION
This should fix this:
https://github.com/SpikeInterface/spikesorters/issues/163