### PR TITLE
Implement get_ttl_events method for available extractors

### DIFF
--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -785,22 +785,22 @@ def check_get_ttl_args(func):
             recording = args[0]
             start_frame = kwargs.get('start_frame', None)
             end_frame = kwargs.get('end_frame', None)
-            channel = kwargs.get('channel', 0)
+            channel_id = kwargs.get('channel_id', 0)
         elif len(args) == 2:
             recording = args[0]
             start_frame = args[1]
             end_frame = kwargs.get('end_frame', None)
-            channel = kwargs.get('channel', 0)
+            channel_id = kwargs.get('channel_id', 0)
         elif len(args) == 3:
             recording = args[0]
             start_frame = args[1]
             end_frame = args[2]
-            channel = kwargs.get('channel', 0)
+            channel_id = kwargs.get('channel_id', 0)
         elif len(args) == 4:
             recording = args[0]
             start_frame = args[1]
             end_frame = args[2]
-            channel = args[3]
+            channel_id = args[3]
         else:
             raise Exception("Too many arguments!")
 
@@ -818,12 +818,12 @@ def check_get_ttl_args(func):
         else:
             end_frame = recording.get_num_frames()
         assert end_frame - start_frame > 0, "'start_frame' must be less than 'end_frame'!"
-        assert isinstance(channel, (int, np.integer)), "'channel' must be a single int"
+        assert isinstance(channel_id, (int, np.integer)), "'channel_id' must be a single int"
 
         start_frame, end_frame = cast_start_end_frame(start_frame, end_frame)
         kwargs['start_frame'] = start_frame
         kwargs['end_frame'] = end_frame
-        kwargs['channel'] = channel
+        kwargs['channel_id'] = channel_id
 
         # pass recording as arg and rest as kwargs
         get_ttl_correct_arg = func(args[0], **kwargs)

--- a/spikeextractors/extraction_tools.py
+++ b/spikeextractors/extraction_tools.py
@@ -777,6 +777,61 @@ def check_get_traces_args(func):
     return corrected_args
 
 
+def check_get_ttl_args(func):
+    @wraps(func)
+    def corrected_args(*args, **kwargs):
+        # parse args and kwargs
+        if len(args) == 1:
+            recording = args[0]
+            start_frame = kwargs.get('start_frame', None)
+            end_frame = kwargs.get('end_frame', None)
+            channel = kwargs.get('channel', 0)
+        elif len(args) == 2:
+            recording = args[0]
+            start_frame = args[1]
+            end_frame = kwargs.get('end_frame', None)
+            channel = kwargs.get('channel', 0)
+        elif len(args) == 3:
+            recording = args[0]
+            start_frame = args[1]
+            end_frame = args[2]
+            channel = kwargs.get('channel', 0)
+        elif len(args) == 4:
+            recording = args[0]
+            start_frame = args[1]
+            end_frame = args[2]
+            channel = args[3]
+        else:
+            raise Exception("Too many arguments!")
+
+        if start_frame is not None:
+            if start_frame < 0:
+                start_frame = recording.get_num_frames() + start_frame
+        else:
+            start_frame = 0
+        if end_frame is not None:
+            if end_frame > recording.get_num_frames():
+                print("'end_frame' set to", recording.get_num_frames())
+                end_frame = recording.get_num_frames()
+            elif end_frame < 0:
+                end_frame = recording.get_num_frames() + end_frame
+        else:
+            end_frame = recording.get_num_frames()
+        assert end_frame - start_frame > 0, "'start_frame' must be less than 'end_frame'!"
+        assert isinstance(channel, (int, np.integer)), "'channel' must be a single int"
+
+        start_frame, end_frame = cast_start_end_frame(start_frame, end_frame)
+        kwargs['start_frame'] = start_frame
+        kwargs['end_frame'] = end_frame
+        kwargs['channel'] = channel
+
+        # pass recording as arg and rest as kwargs
+        get_ttl_correct_arg = func(args[0], **kwargs)
+
+        return get_ttl_correct_arg
+    return corrected_args
+
+
 def cast_start_end_frame(start_frame, end_frame):
     if isinstance(start_frame, (float, np.float)):
         start_frame = int(start_frame)

--- a/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
+++ b/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
@@ -1,5 +1,5 @@
 from spikeextractors import RecordingExtractor
-from spikeextractors.extraction_tools import check_get_traces_args, cast_start_end_frame
+from spikeextractors.extraction_tools import check_get_traces_args, check_get_ttl_args
 import numpy as np
 from pathlib import Path
 
@@ -40,15 +40,10 @@ class IntanRecordingExtractor(RecordingExtractor):
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         return self._recording.analog_signals[0].signal[channel_ids, start_frame:end_frame]
 
+    @check_get_ttl_args
     def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
         channels = [np.unique(ev.channels)[0] for ev in self._recording.digital_in_events]
         assert channel in channels, f"Specified 'channel' not found. Available channels are {channels}"
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
-        start_frame, end_frame = cast_start_end_frame(start_frame, end_frame)
-
         ev = self._recording.events[channels.index(channel)]
 
         ttl_frames = (ev.times.rescale("s") * self.get_sampling_frequency()).magnitude.astype(int)

--- a/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
+++ b/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
@@ -41,7 +41,7 @@ class IntanRecordingExtractor(RecordingExtractor):
         return self._recording.analog_signals[0].signal[channel_ids, start_frame:end_frame]
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
+    def get_ttl_events(self, start_frame=None, end_frame=None, channel_id=0):
         channels = [np.unique(ev.channels)[0] for ev in self._recording.digital_in_events]
         assert channel_id in channels, f"Specified 'channel' not found. Available channels are {channels}"
         ev = self._recording.events[channels.index(channel_id)]

--- a/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
+++ b/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
@@ -1,5 +1,6 @@
 from spikeextractors import RecordingExtractor, SortingExtractor
 from spikeextractors.extraction_tools import check_get_traces_args
+import numpy as np
 from pathlib import Path
 
 try:
@@ -7,6 +8,7 @@ try:
     HAVE_INTAN = True
 except ImportError:
     HAVE_INTAN = False
+
 
 class IntanRecordingExtractor(RecordingExtractor):
     extractor_name = 'IntanRecording'
@@ -37,3 +39,9 @@ class IntanRecordingExtractor(RecordingExtractor):
     @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         return self._recording.analog_signals[0].signal[channel_ids, start_frame:end_frame]
+
+    def get_ttl_frames(self, channel=0):
+        channels = [np.unique(ev.channels)[0] for ev in self._recording.digital_in_events]
+        assert channel in channels, f"Specified 'channel' not found. Available channels are {channels}"
+        ev = self._recording.events[channels.index(channel)]
+        return (ev.times.rescale("s") * self.get_sampling_frequency()).magnitude.astype(int)

--- a/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
+++ b/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
@@ -41,10 +41,10 @@ class IntanRecordingExtractor(RecordingExtractor):
         return self._recording.analog_signals[0].signal[channel_ids, start_frame:end_frame]
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
         channels = [np.unique(ev.channels)[0] for ev in self._recording.digital_in_events]
-        assert channel in channels, f"Specified 'channel' not found. Available channels are {channels}"
-        ev = self._recording.events[channels.index(channel)]
+        assert channel_id in channels, f"Specified 'channel' not found. Available channels are {channels}"
+        ev = self._recording.events[channels.index(channel_id)]
 
         ttl_frames = (ev.times.rescale("s") * self.get_sampling_frequency()).magnitude.astype(int)
         ttl_states = np.sign(ev.channel_states)

--- a/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
+++ b/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
@@ -1,5 +1,5 @@
-from spikeextractors import RecordingExtractor, SortingExtractor
-from spikeextractors.extraction_tools import check_get_traces_args
+from spikeextractors import RecordingExtractor
+from spikeextractors.extraction_tools import check_get_traces_args, cast_start_end_frame
 import numpy as np
 from pathlib import Path
 
@@ -40,8 +40,18 @@ class IntanRecordingExtractor(RecordingExtractor):
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         return self._recording.analog_signals[0].signal[channel_ids, start_frame:end_frame]
 
-    def get_ttl_frames(self, channel=0):
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
         channels = [np.unique(ev.channels)[0] for ev in self._recording.digital_in_events]
         assert channel in channels, f"Specified 'channel' not found. Available channels are {channels}"
+        if start_frame is None:
+            start_frame = 0
+        if end_frame is None:
+            end_frame = self.get_num_frames()
+        start_frame, end_frame = cast_start_end_frame(start_frame, end_frame)
+
         ev = self._recording.events[channels.index(channel)]
-        return (ev.times.rescale("s") * self.get_sampling_frequency()).magnitude.astype(int)
+
+        ttl_frames = (ev.times.rescale("s") * self.get_sampling_frequency()).magnitude.astype(int)
+        ttl_states = np.sign(ev.channel_states)
+        ttl_valid_idxs = np.where((ttl_frames >= start_frame) & (ttl_frames < end_frame))[0]
+        return ttl_frames[ttl_valid_idxs], ttl_states[ttl_valid_idxs]

--- a/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
+++ b/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
@@ -1,7 +1,7 @@
 from spikeextractors import RecordingExtractor
 from pathlib import Path
 import numpy as np
-from spikeextractors.extraction_tools import check_get_traces_args
+from spikeextractors.extraction_tools import check_get_traces_args, check_get_ttl_args
 
 try:
     import h5py
@@ -101,10 +101,16 @@ class MaxOneRecordingExtractor(RecordingExtractor):
                 return (self._signals[np.array(channel_ids), start_frame:end_frame] * self._lsb).astype('float32')
         else:
             return (self._signals[np.array(channel_ids), start_frame:end_frame] * self._lsb).astype('float32')
-    
-    def get_ttl_frames(self, channel=0):
+
+    @check_get_ttl_args
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
         bitvals = self._signals[-2:, 0]
         first_frame = bitvals[1] << 16 | bitvals[0]
         bits = self._filehandle['bits']
         bit_frames = bits['frameno'] - first_frame
-        return bit_frames
+        bit_states = bits['bits']
+        bit_idxs = np.where((bit_frames >= start_frame) & (bit_frames < end_frame))[0]
+        ttl_frames = bit_frames[bit_idxs]
+        ttl_states = bit_states['bit_idxs']
+        ttl_states[ttl_states == 0] = -1
+        return ttl_frames, ttl_states

--- a/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
+++ b/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
@@ -103,7 +103,7 @@ class MaxOneRecordingExtractor(RecordingExtractor):
             return (self._signals[np.array(channel_ids), start_frame:end_frame] * self._lsb).astype('float32')
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
+    def get_ttl_events(self, start_frame=None, end_frame=None, channel_id=0):
         bitvals = self._signals[-2:, 0]
         first_frame = bitvals[1] << 16 | bitvals[0]
         bits = self._filehandle['bits']

--- a/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
+++ b/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
@@ -103,7 +103,7 @@ class MaxOneRecordingExtractor(RecordingExtractor):
             return (self._signals[np.array(channel_ids), start_frame:end_frame] * self._lsb).astype('float32')
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
         bitvals = self._signals[-2:, 0]
         first_frame = bitvals[1] << 16 | bitvals[0]
         bits = self._filehandle['bits']

--- a/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
+++ b/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
@@ -131,7 +131,7 @@ class Mea1kRecordingExtractor(RecordingExtractor):
             return (self._signals[np.array(channel_ids), start_frame:end_frame] * self._lsb).astype('float32')
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
+    def get_ttl_events(self, start_frame=None, end_frame=None, channel_id=0):
         bitvals = self._signals[-2:, 0]
         first_frame = bitvals[1] << 16 | bitvals[0]
         bits = self._filehandle['bits']

--- a/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
+++ b/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
@@ -131,7 +131,7 @@ class Mea1kRecordingExtractor(RecordingExtractor):
             return (self._signals[np.array(channel_ids), start_frame:end_frame] * self._lsb).astype('float32')
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
         bitvals = self._signals[-2:, 0]
         first_frame = bitvals[1] << 16 | bitvals[0]
         bits = self._filehandle['bits']

--- a/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
+++ b/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
@@ -1,7 +1,7 @@
 from spikeextractors import RecordingExtractor
 from pathlib import Path
 import numpy as np
-from spikeextractors.extraction_tools import check_get_traces_args
+from spikeextractors.extraction_tools import check_get_traces_args, check_get_ttl_args
 
 try:
     import h5py
@@ -130,12 +130,18 @@ class Mea1kRecordingExtractor(RecordingExtractor):
         else:
             return (self._signals[np.array(channel_ids), start_frame:end_frame] * self._lsb).astype('float32')
 
-    def get_ttl_frames(self, channel=0):
+    @check_get_ttl_args
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
         bitvals = self._signals[-2:, 0]
         first_frame = bitvals[1] << 16 | bitvals[0]
         bits = self._filehandle['bits']
         bit_frames = bits['frameno'] - first_frame
-        return bit_frames
+        bit_states = bits['bits']
+        bit_idxs = np.where((bit_frames >= start_frame) & (bit_frames < end_frame))[0]
+        ttl_frames = bit_frames[bit_idxs]
+        ttl_states = bit_states['bit_idxs']
+        ttl_states[ttl_states == 0] = -1
+        return ttl_frames, ttl_states
 
     @staticmethod
     def write_recording(recording, save_path, chunk_size=None, chunk_mb=500):

--- a/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
+++ b/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
@@ -102,6 +102,13 @@ class Mea1kRecordingExtractor(RecordingExtractor):
             assert channel_ids in self.get_channel_ids()
             return self._signals[np.array(channel_ids), start_frame:end_frame].astype('float32')
 
+    def get_ttl_frames(self, channel=0):
+        bitvals = self._signals[-2:, 0]
+        first_frame = bitvals[1] << 16 | bitvals[0]
+        bits = self._filehandle['bits']
+        bit_frames = bits['frameno'] - first_frame
+        return bit_frames
+
     @staticmethod
     def write_recording(recording, save_path, chunk_size=None, chunk_mb=500):
         assert HAVE_MEA1k, Mea1kRecordingExtractor.installation_mesg

--- a/spikeextractors/extractors/numpyextractors/numpyextractors.py
+++ b/spikeextractors/extractors/numpyextractors/numpyextractors.py
@@ -62,7 +62,7 @@ class NumpyRecordingExtractor(RecordingExtractor):
         return recordings
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
+    def get_ttl_events(self, start_frame=None, end_frame=None, channel_id=0):
         if self._ttl_frames is not None and self._ttl_states is not None:
             ttl_idxs = np.where((self._ttl_frames >= start_frame) & (self._ttl_frames < end_frame))[0]
             return self._ttl_frames[ttl_idxs], self._ttl_states[ttl_idxs]

--- a/spikeextractors/extractors/numpyextractors/numpyextractors.py
+++ b/spikeextractors/extractors/numpyextractors/numpyextractors.py
@@ -62,7 +62,7 @@ class NumpyRecordingExtractor(RecordingExtractor):
         return recordings
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
         if self._ttl_frames is not None and self._ttl_states is not None:
             ttl_idxs = np.where((self._ttl_frames >= start_frame) & (self._ttl_frames < end_frame))[0]
             return self._ttl_frames[ttl_idxs], self._ttl_states[ttl_idxs]

--- a/spikeextractors/extractors/openephysextractors/openephysextractors.py
+++ b/spikeextractors/extractors/openephysextractors/openephysextractors.py
@@ -47,10 +47,10 @@ class OpenEphysRecordingExtractor(RecordingExtractor):
                    self._recording.analog_signals[0].gain
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
         channels = [np.unique(ev.channels)[0] for ev in self._recording.events]
-        assert channel in channels, f"Specified 'channel' not found. Available channels are {channels}"
-        ev = self._recording.events[channels.index(channel)]
+        assert channel_id in channels, f"Specified 'channel' not found. Available channels are {channels}"
+        ev = self._recording.events[channels.index(channel_id)]
 
         ttl_frames = (ev.times.rescale("s") * self.get_sampling_frequency()).magnitude.astype(int)
         ttl_states = np.sign(ev.channel_states)

--- a/spikeextractors/extractors/openephysextractors/openephysextractors.py
+++ b/spikeextractors/extractors/openephysextractors/openephysextractors.py
@@ -46,6 +46,12 @@ class OpenEphysRecordingExtractor(RecordingExtractor):
             return self._recording.analog_signals[0].signal[channel_ids, start_frame:end_frame] * \
                    self._recording.analog_signals[0].gain
 
+    def get_ttl_frames(self, channel=0):
+        channels = [np.unique(ev.channels)[0] for ev in self._recording.events]
+        assert channel in channels, f"Specified 'channel' not found. Available channels are {channels}"
+        ev = self._recording.events[channels.index(channel)]
+        return (ev.times.rescale("s") * self.get_sampling_frequency()).magnitude.astype(int)
+
 
 class OpenEphysSortingExtractor(SortingExtractor):
     extractor_name = 'OpenEphysSortingExtractor'

--- a/spikeextractors/extractors/openephysextractors/openephysextractors.py
+++ b/spikeextractors/extractors/openephysextractors/openephysextractors.py
@@ -47,7 +47,7 @@ class OpenEphysRecordingExtractor(RecordingExtractor):
                    self._recording.analog_signals[0].gain
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
+    def get_ttl_events(self, start_frame=None, end_frame=None, channel_id=0):
         channels = [np.unique(ev.channels)[0] for ev in self._recording.events]
         assert channel_id in channels, f"Specified 'channel' not found. Available channels are {channels}"
         ev = self._recording.events[channels.index(channel_id)]

--- a/spikeextractors/extractors/openephysextractors/openephysextractors.py
+++ b/spikeextractors/extractors/openephysextractors/openephysextractors.py
@@ -1,7 +1,7 @@
 from spikeextractors import RecordingExtractor, SortingExtractor
 from pathlib import Path
 import numpy as np
-from spikeextractors.extraction_tools import check_get_traces_args, check_valid_unit_id, cast_start_end_frame
+from spikeextractors.extraction_tools import check_get_traces_args, check_valid_unit_id, check_get_ttl_args
 
 try:
     import pyopenephys
@@ -46,16 +46,10 @@ class OpenEphysRecordingExtractor(RecordingExtractor):
             return self._recording.analog_signals[0].signal[channel_ids, start_frame:end_frame] * \
                    self._recording.analog_signals[0].gain
 
+    @check_get_ttl_args
     def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
         channels = [np.unique(ev.channels)[0] for ev in self._recording.events]
         assert channel in channels, f"Specified 'channel' not found. Available channels are {channels}"
-
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
-        start_frame, end_frame = cast_start_end_frame(start_frame, end_frame)
-
         ev = self._recording.events[channels.index(channel)]
 
         ttl_frames = (ev.times.rescale("s") * self.get_sampling_frequency()).magnitude.astype(int)

--- a/spikeextractors/extractors/spikeglxrecordingextractor/readSGLX.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/readSGLX.py
@@ -265,7 +265,7 @@ def ExtractDigital(rawData, firstSamp, lastSamp, dwReq, dLineList, meta):
         else:
             digCh = MN + MA + XA + dwReq
 
-    selectData = np.ascontiguousarray(rawData[digCh, firstSamp:lastSamp+1], 'int16')
+    selectData = np.ascontiguousarray(rawData[digCh, firstSamp:lastSamp], 'int16')
     nSamp = lastSamp-firstSamp + 1
 
     # unpack bits of selectData; unpack bits works with uint8

--- a/spikeextractors/extractors/spikeglxrecordingextractor/readSGLX.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/readSGLX.py
@@ -266,7 +266,7 @@ def ExtractDigital(rawData, firstSamp, lastSamp, dwReq, dLineList, meta):
             digCh = MN + MA + XA + dwReq
 
     selectData = np.ascontiguousarray(rawData[digCh, firstSamp:lastSamp], 'int16')
-    nSamp = lastSamp-firstSamp + 1
+    nSamp = lastSamp-firstSamp
 
     # unpack bits of selectData; unpack bits works with uint8
     # origintal data is int16

--- a/spikeextractors/extractors/spikeglxrecordingextractor/readSGLX.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/readSGLX.py
@@ -280,7 +280,7 @@ def ExtractDigital(rawData, firstSamp, lastSamp, dwReq, dLineList, meta):
         byteN, bitN = np.divmod(dLineList[i], 8)
         targI = byteN*8 + (7 - bitN)
         digArray[i, :] = bitWiseData[targI, :]
-    return(digArray)
+    return (digArray)
 
 
 # Sample calling program to get a file from the user,

--- a/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
@@ -90,7 +90,7 @@ class SpikeGLXRecordingExtractor(RecordingExtractor):
         return recordings
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
+    def get_ttl_events(self, start_frame=None, end_frame=None, channel_id=0):
         channel = [channel_id]
         dw = 0
         dig = ExtractDigital(self._raw, firstSamp=start_frame, lastSamp=end_frame, dwReq=dw, dLineList=channel,

--- a/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
@@ -2,7 +2,7 @@ from spikeextractors import RecordingExtractor
 from .readSGLX import readMeta, SampRate, makeMemMapRaw, GainCorrectIM, GainCorrectNI, ExtractDigital
 import numpy as np
 from pathlib import Path
-from spikeextractors.extraction_tools import check_get_traces_args, cast_start_end_frame
+from spikeextractors.extraction_tools import check_get_traces_args, check_get_ttl_args
 
 
 class SpikeGLXRecordingExtractor(RecordingExtractor):
@@ -89,14 +89,8 @@ class SpikeGLXRecordingExtractor(RecordingExtractor):
         recordings = self._timeseries[channel_idxs, start_frame:end_frame]
         return recordings
 
+    @check_get_ttl_args
     def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
-        assert isinstance(channel, (int, np.integer)), "One channel at a time can be returned"
-
-        if start_frame is None:
-            start_frame = 0
-        if end_frame is None:
-            end_frame = self.get_num_frames()
-        start_frame, end_frame = cast_start_end_frame(start_frame, end_frame)
         channel = [channel]
         dw = 0
         dig = ExtractDigital(self._raw, firstSamp=start_frame, lastSamp=end_frame, dwReq=dw, dLineList=channel,

--- a/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
@@ -90,8 +90,8 @@ class SpikeGLXRecordingExtractor(RecordingExtractor):
         return recordings
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
-        channel = [channel]
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
+        channel = [channel_id]
         dw = 0
         dig = ExtractDigital(self._raw, firstSamp=start_frame, lastSamp=end_frame, dwReq=dw, dLineList=channel,
                              meta=self._meta)

--- a/spikeextractors/multirecordingtimeextractor.py
+++ b/spikeextractors/multirecordingtimeextractor.py
@@ -88,14 +88,14 @@ class MultiRecordingTimeExtractor(RecordingExtractor):
         return np.concatenate(traces, axis=1)
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
         recording1, i_sec1, i_start_frame = self._find_section_for_frame(start_frame)
         _, i_sec2, i_end_frame = self._find_section_for_frame(end_frame)
 
         if i_sec1 == i_sec2:
             ttl_frames, ttl_states = recording1.get_ttl_frames(start_frame=i_start_frame,
                                                                end_frame=i_end_frame,
-                                                               channel=channel)
+                                                               channel_id=channel_id)
             ttl_frames += self._start_frames[i_sec1]
         else:
             ttl_frames, ttl_states = [], []
@@ -103,20 +103,20 @@ class MultiRecordingTimeExtractor(RecordingExtractor):
             ttl_frames_1, ttl_states_1 = self._recordings[i_sec1].get_ttl_frames(
                 start_frame=i_start_frame,
                 end_frame=self._recordings[i_sec1].get_num_frames(),
-                channel=channel)
+                channel_id=channel_id)
             ttl_frames_1 = (ttl_frames_1 + self._start_frames[i_sec1]).astype('int64')
             ttl_frames.append(ttl_frames_1)
             ttl_states.append(ttl_states_1)
 
             for i_sec in range(i_sec1 + 1, i_sec2):
-                ttl_frames_i, ttl_states_i = self._recordings[i_sec].get_ttl_frames(channel=channel)
+                ttl_frames_i, ttl_states_i = self._recordings[i_sec].get_ttl_frames(channel_id=channel_id)
                 ttl_frames_i = (ttl_frames_i + self._start_frames[i_sec]).astype('int64')
                 ttl_frames.append(ttl_frames_i)
                 ttl_states.append(ttl_states_i)
 
             ttl_frames_2, ttl_states_2 = self._recordings[i_sec2].get_ttl_frames(start_frame=0,
                                                                                  end_frame=i_end_frame,
-                                                                                 channel=channel)
+                                                                                 channel_id=channel_id)
             ttl_frames_2 = (ttl_frames_2 + self._start_frames[i_sec2]).astype('int64')
             ttl_frames.append(ttl_frames_2)
             ttl_states.append(ttl_states_2)

--- a/spikeextractors/multirecordingtimeextractor.py
+++ b/spikeextractors/multirecordingtimeextractor.py
@@ -88,19 +88,19 @@ class MultiRecordingTimeExtractor(RecordingExtractor):
         return np.concatenate(traces, axis=1)
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
+    def get_ttl_events(self, start_frame=None, end_frame=None, channel_id=0):
         recording1, i_sec1, i_start_frame = self._find_section_for_frame(start_frame)
         _, i_sec2, i_end_frame = self._find_section_for_frame(end_frame)
 
         if i_sec1 == i_sec2:
-            ttl_frames, ttl_states = recording1.get_ttl_frames(start_frame=i_start_frame,
+            ttl_frames, ttl_states = recording1.get_ttl_events(start_frame=i_start_frame,
                                                                end_frame=i_end_frame,
                                                                channel_id=channel_id)
             ttl_frames += self._start_frames[i_sec1]
         else:
             ttl_frames, ttl_states = [], []
 
-            ttl_frames_1, ttl_states_1 = self._recordings[i_sec1].get_ttl_frames(
+            ttl_frames_1, ttl_states_1 = self._recordings[i_sec1].get_ttl_events(
                 start_frame=i_start_frame,
                 end_frame=self._recordings[i_sec1].get_num_frames(),
                 channel_id=channel_id)
@@ -109,12 +109,12 @@ class MultiRecordingTimeExtractor(RecordingExtractor):
             ttl_states.append(ttl_states_1)
 
             for i_sec in range(i_sec1 + 1, i_sec2):
-                ttl_frames_i, ttl_states_i = self._recordings[i_sec].get_ttl_frames(channel_id=channel_id)
+                ttl_frames_i, ttl_states_i = self._recordings[i_sec].get_ttl_events(channel_id=channel_id)
                 ttl_frames_i = (ttl_frames_i + self._start_frames[i_sec]).astype('int64')
                 ttl_frames.append(ttl_frames_i)
                 ttl_states.append(ttl_states_i)
 
-            ttl_frames_2, ttl_states_2 = self._recordings[i_sec2].get_ttl_frames(start_frame=0,
+            ttl_frames_2, ttl_states_2 = self._recordings[i_sec2].get_ttl_events(start_frame=0,
                                                                                  end_frame=i_end_frame,
                                                                                  channel_id=channel_id)
             ttl_frames_2 = (ttl_frames_2 + self._start_frames[i_sec2]).astype('int64')

--- a/spikeextractors/multirecordingtimeextractor.py
+++ b/spikeextractors/multirecordingtimeextractor.py
@@ -1,5 +1,5 @@
 from .recordingextractor import RecordingExtractor
-from .extraction_tools import check_get_traces_args
+from .extraction_tools import check_get_traces_args, check_get_ttl_args
 import numpy as np
 
 
@@ -30,9 +30,9 @@ class MultiRecordingTimeExtractor(RecordingExtractor):
             channel_ids = recording.get_channel_ids()
             sampling_frequency = recording.get_sampling_frequency()
 
-            if (self._channel_ids != channel_ids):
+            if self._channel_ids != channel_ids:
                 raise ValueError("Inconsistent channel ids between extractor 0 and extractor " + str(i + 1))
-            if (self._sampling_frequency != sampling_frequency):
+            if self._sampling_frequency != sampling_frequency:
                 raise ValueError("Inconsistent sampling frequency between extractor 0 and extractor " + str(i + 1))
 
         self._start_frames = []
@@ -87,6 +87,45 @@ class MultiRecordingTimeExtractor(RecordingExtractor):
         )
         return np.concatenate(traces, axis=1)
 
+    @check_get_ttl_args
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
+        recording1, i_sec1, i_start_frame = self._find_section_for_frame(start_frame)
+        _, i_sec2, i_end_frame = self._find_section_for_frame(end_frame)
+
+        if i_sec1 == i_sec2:
+            ttl_frames, ttl_states = recording1.get_ttl_frames(start_frame=i_start_frame,
+                                                               end_frame=i_end_frame,
+                                                               channel=channel)
+            ttl_frames += self._start_frames[i_sec1]
+        else:
+            ttl_frames, ttl_states = [], []
+
+            ttl_frames_1, ttl_states_1 = self._recordings[i_sec1].get_ttl_frames(
+                start_frame=i_start_frame,
+                end_frame=self._recordings[i_sec1].get_num_frames(),
+                channel=channel)
+            ttl_frames_1 = (ttl_frames_1 + self._start_frames[i_sec1]).astype('int64')
+            ttl_frames.append(ttl_frames_1)
+            ttl_states.append(ttl_states_1)
+
+            for i_sec in range(i_sec1 + 1, i_sec2):
+                ttl_frames_i, ttl_states_i = self._recordings[i_sec].get_ttl_frames(channel=channel)
+                ttl_frames_i = (ttl_frames_i + self._start_frames[i_sec]).astype('int64')
+                ttl_frames.append(ttl_frames_i)
+                ttl_states.append(ttl_states_i)
+
+            ttl_frames_2, ttl_states_2 = self._recordings[i_sec2].get_ttl_frames(start_frame=0,
+                                                                                 end_frame=i_end_frame,
+                                                                                 channel=channel)
+            ttl_frames_2 = (ttl_frames_2 + self._start_frames[i_sec2]).astype('int64')
+            ttl_frames.append(ttl_frames_2)
+            ttl_states.append(ttl_states_2)
+
+            ttl_frames = np.concatenate(np.array(ttl_frames))
+            ttl_states = np.concatenate(np.array(ttl_states))
+
+        return ttl_frames, ttl_states
+
     def get_channel_ids(self):
         return self._channel_ids
 
@@ -103,6 +142,7 @@ class MultiRecordingTimeExtractor(RecordingExtractor):
     def time_to_frame(self, time):
         recording, i_epoch, rel_time = self._find_section_for_time(time)
         return recording.time_to_frame(rel_time) + self._start_frames[i_epoch]
+
 
 def concatenate_recordings_by_time(recordings, epoch_names=None):
     '''

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -762,7 +762,7 @@ class RecordingExtractor(ABC, BaseExtractor):
                                                       return_property_list=return_property_list)
             return sub_list
 
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
         '''
         Returns an array with frames of TTL signals. To be implemented in sub-classes
 
@@ -772,8 +772,8 @@ class RecordingExtractor(ABC, BaseExtractor):
             The starting frame of the ttl to be returned (inclusive)
         end_frame: int
             The ending frame of the ttl to be returned (exclusive)
-        channel: int
-            The TTL channel
+        channel_id: int
+            The TTL channel id
 
         Returns
         -------

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -762,12 +762,16 @@ class RecordingExtractor(ABC, BaseExtractor):
                                                       return_property_list=return_property_list)
             return sub_list
 
-    def get_ttl_frames(self, channel=0):
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
         '''
         Returns an array with frames of TTL signals. To be implemented in sub-classes
 
         Parameters
         ----------
+        start_frame: int
+            The starting frame of the ttl to be returned (inclusive)
+        end_frame: int
+            The ending frame of the ttl to be returned (exclusive)
         channel: int
             The TTL channel
 
@@ -775,6 +779,8 @@ class RecordingExtractor(ABC, BaseExtractor):
         -------
         ttl_frames: array-like
             Frames of TTL signal for the specified channel
+        ttl_state: array-like
+            State of the transition: 1 - rising, -1 - falling
         '''
         raise NotImplementedError
 

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -762,7 +762,7 @@ class RecordingExtractor(ABC, BaseExtractor):
                                                       return_property_list=return_property_list)
             return sub_list
 
-    def get_ttl(self, channel=0):
+    def get_ttl_frames(self, channel=0):
         '''
         Returns an array with frames of TTL signals. To be implemented in sub-classes
 

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -762,7 +762,7 @@ class RecordingExtractor(ABC, BaseExtractor):
                                                       return_property_list=return_property_list)
             return sub_list
 
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
+    def get_ttl_events(self, start_frame=None, end_frame=None, channel_id=0):
         '''
         Returns an array with frames of TTL signals. To be implemented in sub-classes
 

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -762,6 +762,22 @@ class RecordingExtractor(ABC, BaseExtractor):
                                                       return_property_list=return_property_list)
             return sub_list
 
+    def get_ttl(self, channel=0):
+        '''
+        Returns an array with frames of TTL signals. To be implemented in sub-classes
+
+        Parameters
+        ----------
+        channel: int
+            The TTL channel
+
+        Returns
+        -------
+        ttl_frames: array-like
+            Frames of TTL signal for the specified channel
+        '''
+        raise NotImplementedError
+
     @staticmethod
     def write_recording(recording, save_path):
         '''This function writes out the recorded file of a given recording

--- a/spikeextractors/subrecordingextractor.py
+++ b/spikeextractors/subrecordingextractor.py
@@ -41,17 +41,17 @@ class SubRecordingExtractor(RecordingExtractor):
         return self._parent_recording.get_traces(channel_ids=original_ch_ids, start_frame=sf, end_frame=ef)
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
+    def get_ttl_events(self, start_frame=None, end_frame=None, channel_id=0):
         sf = self._start_frame + start_frame
         ef = self._start_frame + end_frame
         sf, ef = cast_start_end_frame(sf, ef)
         try:
-            ttl_frames, ttl_states = self._parent_recording.get_ttl_frames(start_frame=sf, end_frame=ef,
+            ttl_frames, ttl_states = self._parent_recording.get_ttl_events(start_frame=sf, end_frame=ef,
                                                                            channel_id=channel_id)
             ttl_frames -= self._start_frame
             return ttl_frames, ttl_states
         except NotImplementedError:
-            raise NotImplementedError("The parent recording does implement the 'get_ttl_frames method'")
+            raise NotImplementedError("The parent recording does implement the 'get_ttl_events method'")
 
     def get_channel_ids(self):
         return list(self._renamed_channel_ids)

--- a/spikeextractors/subrecordingextractor.py
+++ b/spikeextractors/subrecordingextractor.py
@@ -1,10 +1,9 @@
 from .recordingextractor import RecordingExtractor
-from .extraction_tools import check_get_traces_args, cast_start_end_frame
+from .extraction_tools import check_get_traces_args, cast_start_end_frame, check_get_ttl_args
 import numpy as np
 
 
 # Encapsulates a sub-dataset
-
 class SubRecordingExtractor(RecordingExtractor):
     def __init__(self, parent_recording, *, channel_ids=None, renamed_channel_ids=None, start_frame=None,
                  end_frame=None):
@@ -40,6 +39,19 @@ class SubRecordingExtractor(RecordingExtractor):
         ef = self._start_frame + end_frame
         original_ch_ids = self.get_original_channel_ids(channel_ids)
         return self._parent_recording.get_traces(channel_ids=original_ch_ids, start_frame=sf, end_frame=ef)
+
+    @check_get_ttl_args
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
+        sf = self._start_frame + start_frame
+        ef = self._start_frame + end_frame
+        sf, ef = cast_start_end_frame(sf, ef)
+        try:
+            ttl_frames, ttl_states = self._parent_recording.get_ttl_frames(start_frame=sf, end_frame=ef,
+                                                                           channel=channel)
+            ttl_frames -= self._start_frame
+            return ttl_frames, ttl_states
+        except NotImplementedError:
+            raise NotImplementedError("The parent recording does implement the 'get_ttl_frames method'")
 
     def get_channel_ids(self):
         return list(self._renamed_channel_ids)

--- a/spikeextractors/subrecordingextractor.py
+++ b/spikeextractors/subrecordingextractor.py
@@ -41,13 +41,13 @@ class SubRecordingExtractor(RecordingExtractor):
         return self._parent_recording.get_traces(channel_ids=original_ch_ids, start_frame=sf, end_frame=ef)
 
     @check_get_ttl_args
-    def get_ttl_frames(self, start_frame=None, end_frame=None, channel=0):
+    def get_ttl_frames(self, start_frame=None, end_frame=None, channel_id=0):
         sf = self._start_frame + start_frame
         ef = self._start_frame + end_frame
         sf, ef = cast_start_end_frame(sf, ef)
         try:
             ttl_frames, ttl_states = self._parent_recording.get_ttl_frames(start_frame=sf, end_frame=ef,
-                                                                           channel=channel)
+                                                                           channel_id=channel_id)
             ttl_frames -= self._start_frame
             return ttl_frames, ttl_states
         except NotImplementedError:

--- a/spikeextractors/subsortingextractor.py
+++ b/spikeextractors/subsortingextractor.py
@@ -4,7 +4,6 @@ from .extraction_tools import check_valid_unit_id
 
 
 # Encapsulates a subset of a spike sorted data file
-
 class SubSortingExtractor(SortingExtractor):
     def __init__(self, parent_sorting, *, unit_ids=None, renamed_unit_ids=None, start_frame=None, end_frame=None):
         SortingExtractor.__init__(self)

--- a/spikeextractors/tests/test_extractors.py
+++ b/spikeextractors/tests/test_extractors.py
@@ -94,7 +94,7 @@ class TestExtractors(unittest.TestCase):
         self.assertEqual(self.SX.get_unit_ids(), self.example_info['unit_ids'])
         self.assertEqual(self.RX.get_channel_locations(0)[0][0], self.example_info['channel_prop'][0])
         self.assertEqual(self.RX.get_channel_locations(0)[0][1], self.example_info['channel_prop'][1])
-        self.assertTrue(np.array_equal(self.RX.get_ttl_frames()[0], self.example_info['ttls']))
+        self.assertTrue(np.array_equal(self.RX.get_ttl_events()[0], self.example_info['ttls']))
         self.assertEqual(self.SX.get_unit_property(unit_id=1, property_name='stability'),
                          self.example_info['unit_prop'])
         self.assertTrue(np.array_equal(self.SX.get_unit_spike_train(1), self.example_info['train1']))
@@ -354,19 +354,19 @@ class TestExtractors(unittest.TestCase):
         start_frame = self.example_info['num_frames'] // 3
         end_frame = 2 * self.example_info['num_frames'] // 3
         RX_sub = se.SubRecordingExtractor(self.RX, start_frame=start_frame, end_frame=end_frame)
-        original_ttls = self.RX.get_ttl_frames()[0]
+        original_ttls = self.RX.get_ttl_events()[0]
         ttls_in_sub = original_ttls[np.where((original_ttls >= start_frame) & (original_ttls < end_frame))[0]]
-        self.assertTrue(np.array_equal(RX_sub.get_ttl_frames()[0], ttls_in_sub - start_frame))
+        self.assertTrue(np.array_equal(RX_sub.get_ttl_events()[0], ttls_in_sub - start_frame))
 
         # multirecording
         RX_multi = se.MultiRecordingTimeExtractor(recordings=[self.RX, self.RX, self.RX])
-        ttls_originals = self.RX.get_ttl_frames()[0]
+        ttls_originals = self.RX.get_ttl_events()[0]
         num_ttls = len(ttls_originals)
-        self.assertEqual(len(RX_multi.get_ttl_frames()[0]), 3 * num_ttls)
-        self.assertTrue(np.array_equal(RX_multi.get_ttl_frames()[0][:num_ttls], ttls_originals))
-        self.assertTrue(np.array_equal(RX_multi.get_ttl_frames()[0][num_ttls:2 * num_ttls],
+        self.assertEqual(len(RX_multi.get_ttl_events()[0]), 3 * num_ttls)
+        self.assertTrue(np.array_equal(RX_multi.get_ttl_events()[0][:num_ttls], ttls_originals))
+        self.assertTrue(np.array_equal(RX_multi.get_ttl_events()[0][num_ttls:2 * num_ttls],
                                        ttls_originals + self.RX.get_num_frames()))
-        self.assertTrue(np.array_equal(RX_multi.get_ttl_frames()[0][2 * num_ttls:],
+        self.assertTrue(np.array_equal(RX_multi.get_ttl_events()[0][2 * num_ttls:],
                                        ttls_originals + 2 * self.RX.get_num_frames()))
 
     def test_multi_sub_sorting_extractor(self):

--- a/spikeextractors/tests/test_numpy_extractors.py
+++ b/spikeextractors/tests/test_numpy_extractors.py
@@ -7,7 +7,8 @@ class TestNumpyExtractors(unittest.TestCase):
     def setUp(self):
         M = 4
         N = 10000
-        seed= 0
+        N_ttl = 50
+        seed = 0
         sampling_frequency = 30000
         X = np.random.RandomState(seed=seed).normal(0, 1, (M, N))
         geom = np.random.RandomState(seed=seed).normal(0, 1, (M, 2))
@@ -15,6 +16,8 @@ class TestNumpyExtractors(unittest.TestCase):
         self._geom = geom
         self._sampling_frequency = sampling_frequency
         self.RX = se.NumpyRecordingExtractor(timeseries=X, sampling_frequency=sampling_frequency, geom=geom)
+        self._ttl_frames = np.sort(np.random.permutation(N)[:N_ttl])
+        self.RX.set_ttls(self._ttl_frames)
         self.SX = se.NumpySortingExtractor()
         L = 200
         self._train1 = np.rint(np.random.RandomState(seed=seed).uniform(0, N, L)).astype(int)
@@ -46,6 +49,8 @@ class TestNumpyExtractors(unittest.TestCase):
         # get_snippets
         snippets = self.RX.get_snippets(reference_frames=[0, 30, 50], snippet_len=20)
         self.assertTrue(np.allclose(snippets[1], self._X[:, 20:40]))
+        # get_ttl_frames
+        self.assertTrue(np.array_equal(self.RX.get_ttl_frames()[0], self._ttl_frames))
 
     def test_sorting_extractor(self):
         unit_ids = [1, 2, 3]

--- a/spikeextractors/tests/test_numpy_extractors.py
+++ b/spikeextractors/tests/test_numpy_extractors.py
@@ -49,8 +49,8 @@ class TestNumpyExtractors(unittest.TestCase):
         # get_snippets
         snippets = self.RX.get_snippets(reference_frames=[0, 30, 50], snippet_len=20)
         self.assertTrue(np.allclose(snippets[1], self._X[:, 20:40]))
-        # get_ttl_frames
-        self.assertTrue(np.array_equal(self.RX.get_ttl_frames()[0], self._ttl_frames))
+        # get_ttl_events
+        self.assertTrue(np.array_equal(self.RX.get_ttl_events()[0], self._ttl_frames))
 
     def test_sorting_extractor(self):
         unit_ids = [1, 2, 3]


### PR DESCRIPTION
This PR implements the `get_ttl_events` method, which returns the frame time of digital channels used for synchronization.

The method signature is : `get_ttl_events(self, start_frame=None, end_frame=None, channel_id=0)`, where `channel_id` is the channel of the digital signal to be returned. 

The method returns:
- ttl_frames: np.array with frames at which TTL occur
- ttl_state: np.array of the same length with +1 (rising) and -1 (falling) 

Currently implemented in:
- SubRecordingExtractor
- MultiRecordingTimeExtractor
- NumpyRecrdingExtractor (for adde tests)
- SpikeGLXRecordingExtractor
- OpenEphysRecordingExtractor
- IntanRecordingExtractor
- Mea1kRecordingExtractor
- MaxOneRecordingExtractor