### PR TITLE
quick fix for detecting higher value .res.%i and .res.%i ids

### DIFF
--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -184,7 +184,8 @@ class NeuroscopeSortingExtractor(SortingExtractor):
             resfile_path = Path(resfile_path)
             clufile_path = Path(clufile_path)
             assert resfile_path.is_file() and clufile_path.is_file(), \
-                'The resfile_path and clufile_path must be .res and .clu files!'
+                'The resfile_path ({}) and clufile_path ({}) must be .res and .clu files!'.format(resfile_path,
+                                                                                                  clufile_path)
 
             assert folder_path is None, 'Pass either a single folder_path location, ' \
                                         'or a pair of resfile_path and clufile_path. All received.'
@@ -407,8 +408,8 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
             'For single .res and .clu files, use the NeuroscopeSortingExtractor instead.'
         assert len(res_files) == len(clu_files)
 
-        res_ids = [int(x.name[-1]) for x in res_files]
-        clu_ids = [int(x.name[-1]) for x in res_files]
+        res_ids = [int(x.suffix[1:]) for x in res_files]
+        clu_ids = [int(x.suffix[1:]) for x in clu_files]
         assert sorted(res_ids) == sorted(clu_ids), 'Unmatched .clu.%i and .res.%i files detected!'
         if any([x not in res_ids for x in exclude_shanks]):
             print('Warning: Detected indices in exclude_shanks that are not in the directory. These will be ignored.')

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -380,14 +380,15 @@ class NwbRecordingExtractor(se.RecordingExtractor):
 
         if len(metadata.keys()) > 0:
             if 'Ecephys' in metadata and 'ElectrodeGroup' in metadata['Ecephys']:
-                if type(metadata['Ecephys']['ElectrodeGroup']) is list  and metadata['Ecephys']['ElectrodeGroup']:
+                if type(metadata['Ecephys']['ElectrodeGroup']) is list and metadata['Ecephys']['ElectrodeGroup']:
                     for j, grp in enumerate(metadata['Ecephys']['ElectrodeGroup']):
                         if type(grp) is dict:
                             # Will not overwrite the named electrode_group if already in nwbfile
                             if grp.get('name', defaults['name']) not in nwbfile.electrode_groups:
                                 # If named device link in electrode group does not exist, make it
                                 if grp.get('device_name', default_dev_name) not in nwbfile.devices:
-                                    new_device = {'Ecephys': {'Device': {'name': grp.get('device_name', default_dev_name)}}}
+                                    new_device = {'Ecephys': {'Device': {'name':
+                                                                         grp.get('device_name', default_dev_name)}}}
                                     se.NwbRecordingExtractor.add_devices(recording, nwbfile, metadata=new_device)
                                     print("Warning: device name not detected in attempted link to electrode group! "
                                           "Automatically generating.")
@@ -396,10 +397,10 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                                 electrode_group_kwargs.update(
                                     {'device': nwbfile.devices[grp.get('device_name', default_dev_name)]})
                                 nwbfile.create_electrode_group(**electrode_group_kwargs)
-                    else:
-                        print(f"Warning: Expected metadata['Ecephys']['ElectrodeGroup'][{j}] to be"
-                              " a dictionary with keys 'name', 'description', 'location', and 'device'!"
-                              f"Electrode Group [{j}] will not be created.")
+                        else:
+                            print(f"Warning: Expected metadata['Ecephys']['ElectrodeGroup'][{j}] to be"
+                                  " a dictionary with keys 'name', 'description', 'location', and 'device'!"
+                                  f"Electrode Group [{j}] will not be created.")
                 else:
                     print("Warning: metadata must be a list of dictionaries of the form"
                           " metadata['Ecephys']['ElectrodeGroup'] = [{'name': my_name,"


### PR DESCRIPTION
Ran into a somewhat rare issue where more than two-digits (>9) worth of shanks are used. Pretty easy fix, though.