### PR TITLE
Mea1k fixes and MultiChannelRecordingExtractor locations

### DIFF
--- a/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
+++ b/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
@@ -43,16 +43,40 @@ class MaxOneRecordingExtractor(RecordingExtractor):
         # remove unused channels
         routed_idxs = np.where(electrodes > -1)[0]
         self._channel_ids = list(channels[routed_idxs])
+        self._electrode_ids = list(electrodes[routed_idxs])
         self._num_channels = len(self._channel_ids)
         self._fs = float(20000)
         self._signals = self._filehandle['sig']
         self._num_frames = self._signals.shape[1]
 
-        for i_ch, ch in zip(routed_idxs, self._channel_ids):
+        for i_ch, ch, el in zip(routed_idxs, self._channel_ids, self._electrode_ids):
             self.set_channel_locations([self._mapping['x'][i_ch], self._mapping['y'][i_ch]], ch)
+            self.set_channel_property(ch, 'electrode', el)
+
+        if 'proc0' in self._filehandle:
+            if 'spikeTimes' in self._filehandle['proc0']:
+                spikes = self._filehandle['proc0']['spikeTimes']
+
+                spike_mask = [True] * len(spikes)
+                for i, ch in enumerate(spikes['channel']):
+                    if ch not in self._channel_ids:
+                        spike_mask[i] = False
+                spikes_channels = np.array(spikes['channel'])[spike_mask]
+
+                # load activity as property
+                activity_channels, counts = np.unique(spikes_channels, return_counts=True)
+                activity_channels = list(activity_channels)
+                for ch in self.get_channel_ids():
+                    if ch in activity_channels:
+                        self.set_channel_property(ch, 'activity', counts[activity_channels.index(ch)])
+                    else:
+                        self.set_channel_property(ch, 'activity', 0)
 
     def get_channel_ids(self):
         return list(self._channel_ids)
+
+    def get_electrode_ids(self):
+        return list(self._electrode_ids)
 
     def get_num_frames(self):
         return self._num_frames

--- a/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
+++ b/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
@@ -65,6 +65,9 @@ class MaxOneRecordingExtractor(RecordingExtractor):
 
                 # load activity as property
                 activity_channels, counts = np.unique(spikes_channels, return_counts=True)
+                # transform to spike rate
+                duration = float(self._num_frames) / self._fs
+                counts = counts.astype(float) / duration
                 activity_channels = list(activity_channels)
                 for ch in self.get_channel_ids():
                     if ch in activity_channels:

--- a/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
+++ b/spikeextractors/extractors/maxonerecordingextractor/maxonerecordingextractor.py
@@ -41,13 +41,14 @@ class MaxOneRecordingExtractor(RecordingExtractor):
         channels = np.array(self._mapping['channel'])
         electrodes = np.array(self._mapping['electrode'])
         # remove unused channels
-        self._channel_ids = list(channels[np.where(electrodes > 0)])
+        routed_idxs = np.where(electrodes > -1)[0]
+        self._channel_ids = list(channels[routed_idxs])
         self._num_channels = len(self._channel_ids)
         self._fs = float(20000)
         self._signals = self._filehandle['sig']
         self._num_frames = self._signals.shape[1]
 
-        for i_ch, ch in enumerate(self.get_channel_ids()):
+        for i_ch, ch in zip(routed_idxs, self._channel_ids):
             self.set_channel_locations([self._mapping['x'][i_ch], self._mapping['y'][i_ch]], ch)
 
     def get_channel_ids(self):

--- a/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
+++ b/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
@@ -76,14 +76,38 @@ class Mea1kRecordingExtractor(RecordingExtractor):
         # remove unused channels
         routed_idxs = np.where(electrodes > -1)[0]
         self._channel_ids = list(channels[routed_idxs])
+        self._electrode_ids = list(electrodes[routed_idxs])
         self._num_channels = len(self._channel_ids)
         self._num_frames = self._signals.shape[1]
 
-        for i_ch, ch in zip(routed_idxs, self._channel_ids):
+        for i_ch, ch, el in zip(routed_idxs, self._channel_ids, self._electrode_ids):
             self.set_channel_locations([self._mapping['x'][i_ch], self._mapping['y'][i_ch]], ch)
+            self.set_channel_property(ch, 'electrode', el)
+
+        if 'proc0' in self._filehandle:
+            if 'spikeTimes' in self._filehandle['proc0']:
+                spikes = self._filehandle['proc0']['spikeTimes']
+
+                spike_mask = [True] * len(spikes)
+                for i, ch in enumerate(spikes['channel']):
+                    if ch not in self._channel_ids:
+                        spike_mask[i] = False
+                spikes_channels = np.array(spikes['channel'])[spike_mask]
+
+                # load activity as property
+                activity_channels, counts = np.unique(spikes_channels, return_counts=True)
+                activity_channels = list(activity_channels)
+                for ch in self.get_channel_ids():
+                    if ch in activity_channels:
+                        self.set_channel_property(ch, 'activity', counts[activity_channels.index(ch)])
+                    else:
+                        self.set_channel_property(ch, 'activity', 0)
 
     def get_channel_ids(self):
         return list(self._channel_ids)
+
+    def get_electrode_ids(self):
+        return list(self._electrode_ids)
 
     def get_num_frames(self):
         return self._num_frames

--- a/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
+++ b/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
@@ -74,11 +74,12 @@ class Mea1kRecordingExtractor(RecordingExtractor):
         channels = np.array(self._mapping['channel'])
         electrodes = np.array(self._mapping['electrode'])
         # remove unused channels
-        self._channel_ids = list(channels[np.where(electrodes > -1)])
+        routed_idxs = np.where(electrodes > -1)[0]
+        self._channel_ids = list(channels[routed_idxs])
         self._num_channels = len(self._channel_ids)
         self._num_frames = self._signals.shape[1]
 
-        for i_ch, ch in enumerate(self.get_channel_ids()):
+        for i_ch, ch in zip(routed_idxs, self._channel_ids):
             self.set_channel_locations([self._mapping['x'][i_ch], self._mapping['y'][i_ch]], ch)
 
     def get_channel_ids(self):

--- a/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
+++ b/spikeextractors/extractors/mea1krecordingextractor/mea1krecordingextractor.py
@@ -96,6 +96,9 @@ class Mea1kRecordingExtractor(RecordingExtractor):
 
                 # load activity as property
                 activity_channels, counts = np.unique(spikes_channels, return_counts=True)
+                # transform to spike rate
+                duration = float(self._num_frames) / self._fs
+                counts = counts.astype(float) / duration
                 activity_channels = list(activity_channels)
                 for ch in self.get_channel_ids():
                     if ch in activity_channels:

--- a/spikeextractors/multirecordingchannelextractor.py
+++ b/spikeextractors/multirecordingchannelextractor.py
@@ -13,8 +13,7 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
         # Sampling frequency based off the initial extractor
         self._first_recording = recordings[0]
         self._sampling_frequency = self._first_recording.get_sampling_frequency()
-        self._num_frames =  self._first_recording.get_num_frames()
-
+        self._num_frames = self._first_recording.get_num_frames()
 
         # Test if all recording extractors have same sampling frequency
         for i, recording in enumerate(recordings[1:]):
@@ -22,8 +21,8 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
             if (self._sampling_frequency != sampling_frequency):
                 raise ValueError("Inconsistent sampling frequency between extractor 0 and extractor " + str(i + 1))
 
-        #set channel map for new channel ids to old channel ids
-        new_channel_id  = 0
+        # set channel map for new channel ids to old channel ids
+        new_channel_id = 0
         for r_i, recording in enumerate(self._recordings):
             channel_ids = recording.get_channel_ids()
             for channel_id in channel_ids:
@@ -32,16 +31,25 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
                 new_channel_id += 1
 
         RecordingExtractor.__init__(self)
-        
-        #set group information for channels if available
+
+        # set group information for channels if available
         if groups is not None:
             if len(groups) == len(recordings):
                 for i, group in enumerate(groups):
-                    recording = recordings[i]                    
+                    recording = recordings[i]
                     channel_ids = recording.get_channel_ids()
                     recording.set_channel_groups(groups=np.repeat(group, len(channel_ids)), channel_ids=channel_ids)
             else:
                 raise ValueError("recordings and groups must have same length")
+
+        # set channel locations
+        self._key_properties['locations'] = np.array([])
+        for i, recording in enumerate(recordings):
+            if i == 0:
+                self._key_properties['location'] = recording._key_properties['location']
+            else:
+                self._key_properties['location'] = np.vstack((self._key_properties['location'],
+                                                              recording._key_properties['location']))
         self._kwargs = {'recordings': [rec.make_serialized_dict() for rec in recordings], 'groups': groups}
 
     @property
@@ -55,11 +63,13 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
             for channel_id in channel_ids:
                 recording = self._recordings[self._channel_map[channel_id]['recording']]
                 channel_id_recording = self._channel_map[channel_id]['channel_id']
-                traces_recording = recording.get_traces(channel_ids=[channel_id_recording], start_frame=start_frame, end_frame=end_frame)
+                traces_recording = recording.get_traces(channel_ids=[channel_id_recording], start_frame=start_frame,
+                                                        end_frame=end_frame)
                 traces.append(traces_recording)
         else:
             for recording in self._recordings:
-                traces_all_recording = recording.get_traces(channel_ids=channel_ids, start_frame=start_frame, end_frame=end_frame)
+                traces_all_recording = recording.get_traces(channel_ids=channel_ids, start_frame=start_frame,
+                                                            end_frame=end_frame)
                 traces.append(traces_all_recording)
         return np.concatenate(traces, axis=0)
 
@@ -87,7 +97,8 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
         channel_id_recording = self._channel_map[channel_id]['channel_id']
         property_names = recording.get_channel_property_names(channel_id_recording)
         return property_names
-    
+
+
 def concatenate_recordings_by_channel(recordings, groups=None):
     '''
     Concatenates recordings together by channel. The order of the recordings


### PR DESCRIPTION
### Mea1k fixes

- fix channel locations (only for routed electrodes)

- load spike rates as `activity` property

- implement `get_electrode_ids`

### MultiChannelRecordingExtractor

- add `_key_properties['locations']` as the concatenation of each recording's locations