### PR TITLE
Refactor of add_devices in NwbRecordingExtractor

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -821,8 +821,6 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             "Either pass a save_path location, or nwbfile object, but not both!"
 
         # Update any previous metadata with user passed dictionary
-        if metadata is None:
-            metadata = dict()
         if hasattr(recording, 'nwb_metadata'):
             metadata = update_dict(recording.nwb_metadata, metadata)
 
@@ -840,7 +838,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                     nwbfile_kwargs = dict(session_description='no description',
                                           identifier=str(uuid.uuid4()),
                                           session_start_time=datetime.now())
-                    if 'NWBFile' in metadata:
+                    if metadata is not None and 'NWBFile' in metadata:
                         nwbfile_kwargs.update(metadata['NWBFile'])
                     nwbfile = NWBFile(**nwbfile_kwargs)
 

--- a/spikeextractors/tests/test_extractors.py
+++ b/spikeextractors/tests/test_extractors.py
@@ -409,22 +409,19 @@ class TestExtractors(unittest.TestCase):
         SX_nwb = se.NwbSortingExtractor(path2)
         check_sortings_equal(self.SX, SX_nwb)
         check_dumping(SX_nwb)
-        
+
         # Test for handling unit property descriptions argument
         property_descriptions = {'stability': 'this is a description of stability'}
-        se.NwbSortingExtractor.write_sorting(sorting=self.SX, save_path=path1, 
+        se.NwbSortingExtractor.write_sorting(sorting=self.SX, save_path=path1,
                                              property_descriptions=property_descriptions)
         # create new
         path2 = self.test_dir + '/firings_true.nwb'
         se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path2)
-        se.NwbSortingExtractor.write_sorting(sorting=self.SX, save_path=path2, 
+        se.NwbSortingExtractor.write_sorting(sorting=self.SX, save_path=path2,
                                              property_descriptions=property_descriptions)
         SX_nwb = se.NwbSortingExtractor(path2)
         check_sortings_equal(self.SX, SX_nwb)
         check_dumping(SX_nwb)
-        
-        # TODO
-        # Tests for nwbfile argument passing and modification?
 
     def test_nixio_extractor(self):
         path1 = os.path.join(self.test_dir, 'raw.nix')
@@ -463,18 +460,18 @@ class TestExtractors(unittest.TestCase):
         check_recording_return_types(RX_shybrid)
         check_recordings_equal(self.RX, RX_shybrid)
         check_dumping(RX_shybrid)
-        
+
     def test_neuroscope_extractors(self):
         # NeuroscopeRecordingExtractor tests
         nscope_dir = Path(self.test_dir) / 'neuroscope_rec0'
         dat_file = nscope_dir / 'neuroscope_rec0.dat'
         se.NeuroscopeRecordingExtractor.write_recording(self.RX, nscope_dir)
         RX_ns = se.NeuroscopeRecordingExtractor(dat_file)
-        
+
         check_recording_return_types(RX_ns)
         check_recordings_equal(self.RX, RX_ns, force_dtype='int32')
         check_dumping(RX_ns)
-        
+
         check_recording_return_types(RX_ns)
         check_recordings_equal(self.RX, RX_ns, force_dtype='int32')
         check_dumping(RX_ns)
@@ -488,7 +485,7 @@ class TestExtractors(unittest.TestCase):
         check_recording_return_types(RX_ns)
         check_recordings_equal(self.RX, RX_ns)
         check_dumping(RX_ns)
-        
+
         # NeuroscopeSortingExtractor tests
         nscope_dir = Path(self.test_dir) / 'neuroscope_sort0'
         sort_name = 'neuroscope_sort0'
@@ -505,24 +502,24 @@ class TestExtractors(unittest.TestCase):
                                                              keep_mua_units=False)
         check_sorting_return_types(SX_neuroscope_no_mua)
         check_dumping(SX_neuroscope_no_mua)
-        
+
         # Test for extra argument 'keep_mua_units' resulted in the right output
         SX_neuroscope_no_mua = se.NeuroscopeSortingExtractor(resfile_path=initial_sorting_resfile,
                                                              clufile_path=initial_sorting_clufile,
                                                              keep_mua_units=False)
         check_sorting_return_types(SX_neuroscope_no_mua)
         check_dumping(SX_neuroscope_no_mua)
-        
+
         num_original_units = len(SX_neuroscope.get_unit_ids())
-        self.assertEqual(list(SX_neuroscope.get_unit_ids()), list(range(1,num_original_units+1)))
-        self.assertEqual(list(SX_neuroscope_no_mua.get_unit_ids()), list(range(1,num_original_units)))
-        
+        self.assertEqual(list(SX_neuroscope.get_unit_ids()), list(range(1, num_original_units+1)))
+        self.assertEqual(list(SX_neuroscope_no_mua.get_unit_ids()), list(range(1, num_original_units)))
+
         # Tests for the auto-detection of format for NeuroscopeSortingExtractor
         SX_neuroscope_from_fp = se.NeuroscopeSortingExtractor(folder_path=nscope_dir)
         check_sorting_return_types(SX_neuroscope_from_fp)
         check_sortings_equal(self.SX, SX_neuroscope_from_fp)
         check_dumping(SX_neuroscope_from_fp)
-        
+
         # Tests for the NeuroscopeMultiSortingExtractor
         nscope_dir = Path(self.test_dir) / 'neuroscope_sort1'
         SX_multisorting = se.MultiSortingExtractor(sortings=[self.SX, self.SX])  # re-using same SX for simplicity


### PR DESCRIPTION
1) Replaced all nested if checks with single line assertion
2) Better organized initial metadata auto-population and defaults, including auto-creation of default device
3) Replaced dictionary definitions with literals
4) Enforced Numpy docstring/PEP8
5) Enforced PEP8 on our parts of test_extractor