### PR TITLE
refactor to helper function get_nspikes used in write_units

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -85,7 +85,8 @@ def get_nspikes(units_table, unit_id):
     check_nwb_install()
     ids = np.array(units_table.id[:])
     indexes = np.where(ids == unit_id)[0]
-    assert len(indexes), ValueError(f"{unit_id} is an invalid unit_id. Valid ids: {ids}.")
+    if not len(indexes):
+        raise ValueError(f"{unit_id} is an invalid unit_id. Valid ids: {ids}.")
     index = indexes[0]
     if index == 0:
         return units_table['spike_times_index'].data[index]

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -81,14 +81,16 @@ def get_dynamic_table_property(dynamic_table, *, row_ids=None, property_name):
 
 
 def get_nspikes(units_table, unit_id):
-    """Returns the number of spikes for chosen unit."""
+    """Return the number of spikes for chosen unit."""
     check_nwb_install()
-    if unit_id not in units_table.id[:]:
-        raise ValueError(str(unit_id) + " is an invalid unit_id. "
-                                        "Valid ids: " + str(units_table.id[:].tolist()))
-    nSpikes = np.diff([0] + list(units_table['spike_times_index'].data[:])).tolist()
-    ind = np.where(np.array(units_table.id[:]) == unit_id)[0][0]
-    return nSpikes[ind]
+    ids = np.array(units_table.id[:])
+    indexes = np.where(ids == unit_id)[0]
+    assert len(indexes), ValueError(f"{unit_id} is an invalid unit_id. Valid ids: {ids}.")
+    index = indexes[0]
+    if index == 0:
+        return units_table['spike_times_index'].data[index]
+    else:
+        return units_table['spike_times_index'].data[index] - units_table['spike_times_index'].data[index - 1]
 
 
 def most_relevant_ch(traces):


### PR DESCRIPTION
Suggested by @bendichter on the [previous PR](https://github.com/SpikeInterface/spikeextractors/pull/459). 

Only change required to pass tests is the conversion of `units_table.id[:]` from `list` to `np.array` in order for the `ids == unit_id` to evaluate as intended.