### PR TITLE
Let module version be unkkown when dumping to dict

### DIFF
--- a/spikeextractors/baseextractor.py
+++ b/spikeextractors/baseextractor.py
@@ -54,9 +54,14 @@ class BaseExtractor:
         module = class_name.split('.')[0]
         imported_module = importlib.import_module(module)
 
+        try:
+            version = imported_module.__version__
+        except AttributeError:
+            version = 'unknown'
+
         if self.is_dumpable:
             dump_dict = {'class': class_name, 'module': module, 'kwargs': self._kwargs,
-                         'key_properties': self._key_properties, 'version': imported_module.__version__,
+                         'key_properties': self._key_properties, 'version': version,
                          'dumpable': True}
         else:
             dump_dict = {'class': class_name, 'module': module, 'kwargs': {}, 'key_properties': self._key_properties,


### PR DESCRIPTION
Extractors external to spikeinterface (e.g. form `spikeforest_utils` or custom) might not have a `__version__`. This allows the version to be unknown.

Should fix: 
- https://github.com/SpikeInterface/spikeextractors/issues/476
- https://github.com/SpikeInterface/spikeinterface/issues/80

Note that even for external extractors, the `self._kwargs` HAVE to be set, otherwise the dumping mechanism does not work.