### PR TITLE
Removed unused shank_id arg in NeuroscopeSortingExtractor

### DIFF
--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -290,7 +290,7 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         self._spiketrains.append(spike_times)
 
     @check_valid_unit_id
-    def get_unit_spike_train(self, unit_id, shank_id=None, start_frame=None, end_frame=None):
+    def get_unit_spike_train(self, unit_id, start_frame=None, end_frame=None):
         start_frame, end_frame = self._cast_start_end_frame(start_frame, end_frame)
         if start_frame is None:
             start_frame = 0


### PR DESCRIPTION
Remove unused `shank_id` arg from `NeuroscopeSortingExtractor.get_unit_spike_train()`

Fixes https://github.com/SpikeInterface/spikewidgets/issues/69