### PR TITLE
bug fix for intan get_traces()

### DIFF
--- a/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
+++ b/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
@@ -52,15 +52,7 @@ class IntanRecordingExtractor(RecordingExtractor):
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         channel_idxs = np.array([self._channel_ids.index(ch) for ch in channel_ids])
         analog_chans = self._analog_channels[channel_idxs]
-        tr = self._recording._read_analog(
-            channels=analog_chans,
-            i_start=start_frame,
-            i_stop=end_frame
-        )
-        if len(channel_idxs) == 1:
-            return tr.T
-        else:
-            return tr[:, channel_idxs].T
+        return self._recording._read_analog(channels=analog_chans, i_start=start_frame, i_stop=end_frame).T
 
     @check_get_ttl_args
     def get_ttl_events(self, start_frame=None, end_frame=None, channel_id=0):

--- a/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
+++ b/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py
@@ -52,8 +52,15 @@ class IntanRecordingExtractor(RecordingExtractor):
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         channel_idxs = np.array([self._channel_ids.index(ch) for ch in channel_ids])
         analog_chans = self._analog_channels[channel_idxs]
-        return self._recording._read_analog(channels=analog_chans,
-                                            i_start=start_frame, i_stop=end_frame)[:, channel_idxs].T
+        tr = self._recording._read_analog(
+            channels=analog_chans,
+            i_start=start_frame,
+            i_stop=end_frame
+        )
+        if len(channel_idxs) == 1:
+            return tr.T
+        else:
+            return tr[:, channel_idxs].T
 
     @check_get_ttl_args
     def get_ttl_events(self, start_frame=None, end_frame=None, channel_id=0):


### PR DESCRIPTION
Basically, when the `NwbRecordingExtractor.write_recording()` reaches [this step](https://github.com/catalystneuro/spikeextractors/blob/master/spikeextractors/extractors/nwbextractors/nwbextractors.py#L665-L669), the part of `IntanRecordingExtractor.get_traces()` that [indexes channels after it reads them from pyintan](https://github.com/catalystneuro/spikeextractors/blob/master/spikeextractors/extractors/intanrecordingextractor/intanrecordingextractor.py#L55-L56) throws an indexing issue.

This indexing issue does not occur if your channel indices are consecutive starting from 0, and the current fix as of the submission of this PR has only been confirmed to work when extracting a single index (which is the main use for my current purposes).