### PR TITLE
Additional hotfix to NwbRecordingExtractor.add_electrodes()

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -486,7 +486,8 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         else:
             nwb_elec_ids = nwbfile.electrodes.id.data[:]
         for metadata_column in metadata['Ecephys']['Electrodes']:
-            if nwbfile.electrodes is None or metadata_column['name'] not in nwbfile.electrodes.colnames:
+            if (nwbfile.electrodes is None or metadata_column['name'] not in nwbfile.electrodes.colnames) \
+                    and metadata_column['name'] != 'group_name':
                 nwbfile.add_electrode_column(str(metadata_column['name']),
                                              str(metadata_column['description']))
 


### PR DESCRIPTION
A very odd bug that avoided previous detection because other, non error-causing custom columns were added prior to 'group_name' which automatically created the electrode table (i.e., no longer `None`). and hence allowed the current step of `metadata_column['name']` to properly check its existence in the table.

However, if 'group_name' is the first such column to be added to a non-existent electrode table, it causes a downstream error. This PR fixes this for now, but I'll try to think of a more clever way to properly retrieve the safe keys for column additions at that step.