### PR TITLE
small changes to NwbRecordingExtractor add_electrical_series

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -486,7 +486,8 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         else:
             nwb_elec_ids = nwbfile.electrodes.id.data[:]
         for metadata_column in metadata['Ecephys']['Electrodes']:
-            if nwbfile.electrodes is None or metadata_column['name'] not in nwbfile.electrodes.colnames:
+            if (nwbfile.electrodes is None or metadata_column['name'] not in nwbfile.electrodes.colnames) \
+                    and metadata_column['name'] != 'group_name':
                 nwbfile.add_electrode_column(str(metadata_column['name']),
                                              str(metadata_column['description']))
 
@@ -673,7 +674,8 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                             recording=recording,
                             channels_ids=channel_ids
                         ),
-                        iter_axis=1  # nwb standard is time as zero axis
+                        iter_axis=1,  # nwb standard is time as zero axis,
+                        maxshape=(recording.get_num_frames(), recording.get_num_channels())
                     ),
                     compression='gzip'
                 )


### PR DESCRIPTION
@bendichter If the traces return a non-memory map object, and the data generator is used, the `DataChunkIterator` does not know what the true channel dimension is and so leaves it as `unlimited`. Not a huge issue, but this fixes it.

@alejoe91 Opening as draft because I might include some data conversion type stuff here as well.

Note this branch also includes the `add_electrode` hotfix on the other PR, for testing purposes.