### PR TITLE
Allowed for overall and single Neuroscope files

### DIFF
--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -407,8 +407,7 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
                      and len(f.suffixes) == 2]
         clu_files = [f for f in folder_path.iterdir() if f.is_file()
                      and '.clu' in f.suffixes 
-                     and '.temp' not in f.suffixes
-                     and not f.name.endswith('~')
+                     re.search(r'\d+$', f.name) is not None
                      and len(f.suffixes) == 2]
 
         assert len(res_files) > 0 or len(clu_files) > 0, \

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -197,9 +197,15 @@ class NeuroscopeSortingExtractor(SortingExtractor):
             assert folder_path.is_dir(), 'The folder_path must be a directory!'
 
             res_files = [f for f in folder_path.iterdir() if f.is_file()
-                         and '.res' in f.suffixes and '.temp' not in f.suffixes and len(f.suffixes) <= 2]
+                         and '.res' in f.suffixes 
+                         and '.temp' not in f.suffixes
+                         and not f.name.endswith('~')
+                         and len(f.suffixes) == 1]
             clu_files = [f for f in folder_path.iterdir() if f.is_file()
-                         and '.clu' in f.suffixes and '.temp' not in f.suffixes and len(f.suffixes) <= 2]
+                         and '.clu' in f.suffixes 
+                         and '.temp' not in f.suffixes
+                         and not f.name.endswith('~')
+                         and len(f.suffixes) == 1]
 
             assert len(res_files) > 0 or len(clu_files) > 0, \
                 'No .res or .clu files found in the folder_path.'
@@ -397,15 +403,21 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
             'samplingRate').text)  # careful not to confuse it with the lfpsamplingrate
 
         res_files = [f for f in folder_path.iterdir() if f.is_file()
-                     and '.res' in f.suffixes and '.temp' not in f.suffixes and len(f.suffixes) <= 2]
+                     and '.res' in f.suffixes 
+                     and '.temp' not in f.suffixes
+                     and not f.name.endswith('~')
+                     and len(f.suffixes) == 2]
         clu_files = [f for f in folder_path.iterdir() if f.is_file()
-                     and '.clu' in f.suffixes and '.temp' not in f.suffixes and len(f.suffixes) <= 2]
+                     and '.clu' in f.suffixes 
+                     and '.temp' not in f.suffixes
+                     and not f.name.endswith('~')
+                     and len(f.suffixes) == 2]
 
         assert len(res_files) > 0 or len(clu_files) > 0, \
             'No .res or .clu files found in the folder_path.'
-        assert len(res_files) > 1 and len(clu_files) > 1, \
-            'Single .res and .clu pairs found in the folder_path. ' \
-            'For single .res and .clu files, use the NeuroscopeSortingExtractor instead.'
+        # assert len(res_files) > 1 and len(clu_files) > 1, \
+        #     'Single .res and .clu pairs found in the folder_path. ' \
+        #     'For single .res and .clu files, use the NeuroscopeSortingExtractor instead.'
         assert len(res_files) == len(clu_files)
 
         res_ids = [int(x.suffix[1:]) for x in res_files]

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from spikeextractors.extraction_tools import check_valid_unit_id, get_sub_extractors_by_property
 from typing import Union
 import os
+import re
 
 try:
     from lxml import etree as et
@@ -403,11 +404,11 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
 
         res_files = [f for f in folder_path.iterdir() if f.is_file()
                      and '.res' in f.suffixes 
-                     re.search(r'\d+$', f.name) is not None
+                     and re.search(r'\d+$', f.name) is not None
                      and len(f.suffixes) == 2]
         clu_files = [f for f in folder_path.iterdir() if f.is_file()
                      and '.clu' in f.suffixes 
-                     re.search(r'\d+$', f.name) is not None
+                     and re.search(r'\d+$', f.name) is not None
                      and len(f.suffixes) == 2]
 
         assert len(res_files) > 0 or len(clu_files) > 0, \

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -203,7 +203,6 @@ class NeuroscopeSortingExtractor(SortingExtractor):
                          and len(f.suffixes) == 1]
             clu_files = [f for f in folder_path.iterdir() if f.is_file()
                          and '.clu' in f.suffixes 
-                         and '.temp' not in f.suffixes
                          and not f.name.endswith('~')
                          and len(f.suffixes) == 1]
 

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -403,8 +403,7 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
 
         res_files = [f for f in folder_path.iterdir() if f.is_file()
                      and '.res' in f.suffixes 
-                     and '.temp' not in f.suffixes
-                     and not f.name.endswith('~')
+                     re.search(r'\d+$', f.name) is not None
                      and len(f.suffixes) == 2]
         clu_files = [f for f in folder_path.iterdir() if f.is_file()
                      and '.clu' in f.suffixes 

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -413,9 +413,6 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
 
         assert len(res_files) > 0 or len(clu_files) > 0, \
             'No .res or .clu files found in the folder_path.'
-        # assert len(res_files) > 1 and len(clu_files) > 1, \
-        #     'Single .res and .clu pairs found in the folder_path. ' \
-        #     'For single .res and .clu files, use the NeuroscopeSortingExtractor instead.'
         assert len(res_files) == len(clu_files)
 
         res_ids = [int(x.suffix[1:]) for x in res_files]


### PR DESCRIPTION
Multiple `*.res.*` and `*.clu.*` files (one for each shank) as output of *Klusters* (*Neuroscope*) can potentially be located in the same folder next to a single `*.res` and `*.clu` file containing the data for all shanks.
Moreover, the generation of backup files ending with a tilde like `*.res.*~` by text editors like Emacs can cause failure of the `NeuroscopeSortingExtractor` or `NeuroscopeMultiSortingExtractor` classes.
Finally, `NeuroscopeMultiSortingExtractor` would not accept data, if data was recorded with only one shank, i.e. if there were only one `*.res.1` and `*.clu.1` file (because of assertion in line 406).
The introduced changes make NeuroscopeSortingExtractor only look for *.res and *.clu and NeuroscopeMultiSortingExtractor only look for `*.res.*` and `*.clu.*` while making both extractors ignore files whose name ends with a tilde (`~`).