### PR TITLE
copy epochs and tests

### DIFF
--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -634,6 +634,19 @@ class RecordingExtractor(ABC, BaseExtractor):
         return SubRecordingExtractor(parent_recording=self, start_frame=start_frame,
                                      end_frame=end_frame)
 
+    def copy_epochs(self, recording):
+        '''Copy epochs from another recording extractor to the current
+        recording extractor.
+
+        Parameters
+        ----------
+        recording: RecordingExtractor
+            The recording extractor from which the epochs will be copied
+        '''
+        for epoch_name in recording.get_epoch_names():
+            epoch_info = recording.get_epoch_info(epoch_name)
+            self.add_epoch(epoch_name, epoch_info["start_frame"], epoch_info["end_frame"])
+
     def load_probe_file(self, probe_file, channel_map=None, channel_groups=None, verbose=False):
         '''This function returns a SubRecordingExtractor that contains information from the given
         probe file (channel locations, groups, etc.) If a .prb file is given, then 'location' and 'group'

--- a/spikeextractors/sortingextractor.py
+++ b/spikeextractors/sortingextractor.py
@@ -641,6 +641,19 @@ class SortingExtractor(ABC, BaseExtractor):
         return SubSortingExtractor(parent_sorting=self, start_frame=start_frame,
                                    end_frame=end_frame)
 
+    def copy_epochs(self, sorting):
+        '''Copy epochs from another sorting extractor to the current
+        sorting extractor.
+
+        Parameters
+        ----------
+        sorting: SortingExtractor
+            The sorting extractor from which the epochs will be copied
+        '''
+        for epoch_name in sorting.get_epoch_names():
+            epoch_info = sorting.get_epoch_info(epoch_name)
+            self.add_epoch(epoch_name, epoch_info["start_frame"], epoch_info["end_frame"])
+
     def get_sub_extractors_by_property(self, property_name, return_property_list=False):
         '''Returns a list of SubSortingExtractors from this SortingExtractor based on the given
         property_name (e.g. group)

--- a/spikeextractors/tests/test_extractors.py
+++ b/spikeextractors/tests/test_extractors.py
@@ -53,6 +53,12 @@ class TestExtractors(unittest.TestCase):
         SX2.set_unit_property(unit_id=4, property_name='stability', value=80)
         SX2.set_unit_spike_features(unit_id=3, feature_name='widths', value=np.asarray([3] * spike_times2[0]))
         RX.set_channel_locations([0, 0], channel_ids=0)
+        RX.add_epoch("epoch1", 0, 10)
+        RX.add_epoch("epoch2", 10, 20)
+        SX.add_epoch("epoch1", 0, 10)
+        SX.add_epoch("epoch2", 10, 20)
+        RX2.copy_epochs(RX)
+        SX2.copy_epochs(SX)
         for i, unit_id in enumerate(SX2.get_unit_ids()):
             SX2.set_unit_property(unit_id=unit_id, property_name='shared_unit_prop', value=i)
             SX2.set_unit_spike_features(unit_id=unit_id, feature_name='shared_unit_feature',
@@ -81,7 +87,8 @@ class TestExtractors(unittest.TestCase):
             features3=features3,
             unit_prop=80,
             channel_prop=(0, 0),
-            ttls=ttls
+            ttls=ttls,
+            epochs_info=((0, 10), (10, 20))
         )
 
         return (RX, RX2, RX3, SX, SX2, SX3, example_info)
@@ -106,7 +113,6 @@ class TestExtractors(unittest.TestCase):
         self.assertTrue(self.SX2.get_shared_unit_spike_feature_names(), ['shared_unit_feature'])
         self.assertTrue(self.SX2.get_unit_spike_feature_names(3), ['shared_channel_prop', 'widths'])
 
-        print(self.SX3.get_unit_spike_features(0, 'dummy'))
         self.assertTrue(np.array_equal(self.SX3.get_unit_spike_features(0, 'dummy'), self.example_info['features3']))
         self.assertTrue(np.array_equal(self.SX3.get_unit_spike_features(0, 'dummy', start_frame=4),
                                        self.example_info['features3'][1:]))
@@ -124,6 +130,16 @@ class TestExtractors(unittest.TestCase):
                                        self.SX3.get_unit_spike_features(0, 'dummy')))
         self.assertTrue(np.array_equal(sub_extractor_partial.get_unit_spike_features(0, 'dummy'),
                                        self.SX3.get_unit_spike_features(0, 'dummy', start_frame=20, end_frame=46)))
+
+        self.assertEqual(tuple(self.RX.get_epoch_info("epoch1").values()), self.example_info['epochs_info'][0])
+        self.assertEqual(tuple(self.RX.get_epoch_info("epoch2").values()), self.example_info['epochs_info'][1])
+        self.assertEqual(tuple(self.SX.get_epoch_info("epoch1").values()), self.example_info['epochs_info'][0])
+        self.assertEqual(tuple(self.SX.get_epoch_info("epoch2").values()), self.example_info['epochs_info'][1])
+
+        self.assertEqual(tuple(self.RX.get_epoch_info("epoch1").values()), tuple(self.RX2.get_epoch_info("epoch1").values()))
+        self.assertEqual(tuple(self.RX.get_epoch_info("epoch2").values()), tuple(self.RX2.get_epoch_info("epoch2").values()))
+        self.assertEqual(tuple(self.SX.get_epoch_info("epoch1").values()), tuple(self.SX2.get_epoch_info("epoch1").values()))
+        self.assertEqual(tuple(self.SX.get_epoch_info("epoch2").values()), tuple(self.SX2.get_epoch_info("epoch2").values()))
 
         check_recording_return_types(self.RX)
 


### PR DESCRIPTION
Functionality for copying epoch information from recording and sorting extractors. Will be used to fix downstream issues with disappearing epochs.