### PR TITLE
Add 'group' check to add_electrode

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -479,8 +479,10 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         for metadata_column in metadata['Ecephys']['Electrodes']:
             if (nwbfile.electrodes is None or metadata_column['name'] not in nwbfile.electrodes.colnames) \
                     and metadata_column['name'] != 'group_name':
-                nwbfile.add_electrode_column(str(metadata_column['name']),
-                                             str(metadata_column['description']))
+                nwbfile.add_electrode_column(
+                    name=str(metadata_column['name']),
+                    description=str(metadata_column['description'])
+                )
 
         for j, channel_id in enumerate(recording.get_channel_ids()):
             if channel_id not in nwb_elec_ids:
@@ -1039,8 +1041,11 @@ class NwbSortingExtractor(se.SortingExtractor):
                                   'or max_electrode, but there are no electrodes to reference! '
                                   'Column will not be added.')
                         else:
-                            nwbfile.add_unit_column(pr, property_descriptions.get(pr, 'no description'),
-                                                    table=nwbfile.electrodes)
+                            nwbfile.add_unit_column(
+                                name=pr,
+                                description=property_descriptions.get(pr, 'no description'),
+                                table=nwbfile.electrodes
+                            )
                     else:
                         nwbfile.add_unit_column(pr, property_descriptions.get(pr, 'no description'))
 
@@ -1142,9 +1147,8 @@ class NwbSortingExtractor(se.SortingExtractor):
                   "These units will not be over-written.")
 
     @staticmethod
-    def write_sorting(sorting: se.SortingExtractor, save_path: PathType = None,
-                      nwbfile=None, property_descriptions: dict = None,
-                      **nbwbfile_kwargs):
+    def write_sorting(sorting: se.SortingExtractor, save_path: PathType = None, nwbfile=None,
+                      property_descriptions: dict = None, **nwbfile_kwargs):
         '''
         Parameters
         ----------
@@ -1163,7 +1167,7 @@ class NwbSortingExtractor(se.SortingExtractor):
             For each key in this dictionary which matches the name of a unit
             property in sorting, adds the value as a description to that
             custom unit column.
-        nbwbfile_kwargs: dict
+        nwbfile_kwargs: dict
             Information for constructing the nwb file (optional).
             Only used if no nwbfile exists at the save_path, and no nwbfile
             was directly passed.
@@ -1185,14 +1189,12 @@ class NwbSortingExtractor(se.SortingExtractor):
                     kwargs = {'session_description': 'No description',
                               'identifier': str(uuid.uuid4()),
                               'session_start_time': datetime.now()}
-                    kwargs.update(**nbwbfile_kwargs)
+                    kwargs.update(**nwbfile_kwargs)
                     nwbfile = NWBFile(**kwargs)
 
-                se.NwbSortingExtractor.write_units(sorting, nwbfile,
-                                                   property_descriptions)
+                se.NwbSortingExtractor.write_units(sorting, nwbfile, property_descriptions)
 
                 io.write(nwbfile)
         else:
             assert isinstance(nwbfile, NWBFile), "'nwbfile' should be of type pynwb.NWBFile"
-            se.NwbSortingExtractor.write_units(sorting, nwbfile,
-                                               property_descriptions)
+            se.NwbSortingExtractor.write_units(sorting, nwbfile, property_descriptions)

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -129,17 +129,6 @@ def list_get(l, idx, default):
         return default
 
 
-def fill_kwargs_from_defaults(defaults: dict, values: dict = None):
-    kwargs = {}
-    if values is None:
-        for default_property, default_value in defaults.items():
-            kwargs.update({default_property: default_value})
-    else:
-        for default_property, default_value in defaults.items():
-            kwargs.update({default_property: values.get(default_property, default_value)})
-    return kwargs
-
-
 class NwbRecordingExtractor(se.RecordingExtractor):
     extractor_name = 'NwbRecording'
     has_default_locations = True
@@ -443,8 +432,8 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         electrodes (id, x, y, z, imp, loccation, filtering, group_name),
         then the metadata will override their default values.
 
-        Setting 'my_name' to 'group' is not supported as the linking to nwbfile.electrode_groups is handled
-        automatically; please specify the string 'group_name' in this case.
+        Setting 'my_name' to metadata field 'group' is not supported as the linking to
+        nwbfile.electrode_groups is handled automatically; please specify the string 'group_name' in this case.
 
         If no group information is passed via metadata, automatic linking to existing electrode groups,
         possibly including the default, will occur.
@@ -480,6 +469,8 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         assert all([isinstance(x, dict) and set(x.keys()) == set(['name', 'description', 'data'])
                     and isinstance(x['data'], list) for x in metadata['Ecephys']['Electrodes']]), \
             "Expected metadata['Ecephys']['Electrodes'] to be a list of dictionaries!"
+        assert all([x['name'] != 'group' for x in metadata['Ecephys']['Electrodes']]), \
+            "Passing metadata field 'group' is depricated; pass group_name instead!"
 
         if nwbfile.electrodes is None:
             nwb_elec_ids = []
@@ -530,7 +521,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                                 group_name=group_name
                             )
                         )
-                    elif metadata_column['name'] != 'group':
+                    else:
                         if metadata_column['name'] in defaults:
                             electrode_kwargs.update({
                                 metadata_column['name']: list_get(metadata_column['data'], j,


### PR DESCRIPTION
1) Removed unused auxiliary function.
2) Added assertion to check and instruct users to not pass 'group' as an electrode metadata column any more since it is never used, and entirely overridden in functionality by 'group_name'. The docstring had actually indicated this since the refactor, but it was still possible to pass it in to no effect.