### PR TITLE
Write binary dat in parallel

### DIFF
--- a/spikeextractors/cacheextractors.py
+++ b/spikeextractors/cacheextractors.py
@@ -10,7 +10,8 @@ import shutil
 
 
 class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
-    def __init__(self, recording, chunk_size=None, chunk_mb=500, save_path=None, verbose=False):
+    def __init__(self, recording, chunk_size=None, chunk_mb=500, save_path=None, n_jobs=1, joblib_backend='loky',
+                 verbose=False):
         RecordingExtractor.__init__(self)  # init tmp folder before constructing BinDatRecordingExtractor
         tmp_folder = self.get_tmp_folder()
         self._recording = recording
@@ -27,7 +28,8 @@ class CacheRecordingExtractor(BinDatRecordingExtractor, RecordingExtractor):
             self._tmp_file = save_path
         self._dtype = recording.get_dtype()
         recording.write_to_binary_dat_format(save_path=self._tmp_file, dtype=self._dtype, chunk_size=chunk_size,
-                                             chunk_mb=chunk_mb, verbose=verbose)
+                                             chunk_mb=chunk_mb, n_jobs=n_jobs, joblib_backend=joblib_backend,
+                                             verbose=verbose)
         # keep track of filter status when dumping
         self.is_filtered = self._recording.is_filtered
         BinDatRecordingExtractor.__init__(self, self._tmp_file, numchan=recording.get_num_channels(),

--- a/spikeextractors/extractors/mdaextractors/mdaextractors.py
+++ b/spikeextractors/extractors/mdaextractors/mdaextractors.py
@@ -56,7 +56,7 @@ class MdaRecordingExtractor(RecordingExtractor):
         return recordings
 
     def write_to_binary_dat_format(self, save_path, time_axis=0, dtype=None, chunk_size=None, chunk_mb=500,
-                                   verbose=False):
+                                   n_jobs=1, joblib_backend='loky', verbose=False):
         '''Saves the traces of this recording extractor into binary .dat format.
 
         Parameters
@@ -74,6 +74,10 @@ class MdaRecordingExtractor(RecordingExtractor):
             If 'auto' the file is saved in chunks of ~ 500Mb
         chunk_mb: None or int
             Chunk size in Mb (default 500Mb)
+        n_jobs: int
+            Number of jobs to use (Default 1)
+        joblib_backend: str
+            Joblib backend for parallel processing ('loky', 'threading', 'multiprocessing')
         verbose: bool
             If True, output is verbose
         '''
@@ -88,10 +92,12 @@ class MdaRecordingExtractor(RecordingExtractor):
                 print('Error occurred while copying:', e)
                 print('Writing to binary')
                 write_to_binary_dat_format(self, save_path=save_path, time_axis=time_axis, dtype=dtype,
-                                           chunk_size=chunk_size, chunk_mb=chunk_mb, verbose=verbose)
+                                           chunk_size=chunk_size, chunk_mb=chunk_mb, n_jobs=n_jobs,
+                                           joblib_backend=joblib_backend, verbose=verbose)
         else:
             write_to_binary_dat_format(self, save_path=save_path, time_axis=time_axis, dtype=dtype,
-                                       chunk_size=chunk_size, chunk_mb=chunk_mb, verbose=verbose)
+                                       chunk_size=chunk_size, chunk_mb=chunk_mb, n_jobs=n_jobs,
+                                       joblib_backend=joblib_backend,  verbose=verbose)
 
     @staticmethod
     def write_recording(recording, save_path, params=dict(), raw_fname='raw.mda', params_fname='params.json',

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -681,7 +681,7 @@ class RecordingExtractor(ABC, BaseExtractor):
                            graph=graph, geometry=geometry, verbose=verbose)
 
     def write_to_binary_dat_format(self, save_path, time_axis=0, dtype=None, chunk_size=None, chunk_mb=500,
-                                   verbose=False):
+                                   n_jobs=1, joblib_backend='loky', verbose=False):
         '''Saves the traces of this recording extractor into binary .dat format.
 
         Parameters
@@ -699,11 +699,15 @@ class RecordingExtractor(ABC, BaseExtractor):
             If 'auto' the file is saved in chunks of ~ 500Mb
         chunk_mb: None or int
             Chunk size in Mb (default 500Mb)
+        n_jobs: int
+            Number of jobs to use (Default 1)
+        joblib_backend: str
+            Joblib backend for parallel processing ('loky', 'threading', 'multiprocessing')
         verbose: bool
             If True, output is verbose (when chunks are used)
         '''
         write_to_binary_dat_format(self, save_path=save_path, time_axis=time_axis, dtype=dtype, chunk_size=chunk_size,
-                                   chunk_mb=chunk_mb, verbose=verbose)
+                                   chunk_mb=chunk_mb, n_jobs=n_jobs, joblib_backend=joblib_backend, verbose=verbose)
 
     def write_to_h5_dataset_format(self, dataset_path, save_path=None, file_handle=None,
                                    time_axis=0, dtype=None, chunk_size=None, chunk_mb=500, verbose=False):

--- a/spikeextractors/tests/test_tools.py
+++ b/spikeextractors/tests/test_tools.py
@@ -93,5 +93,20 @@ class TestTools(unittest.TestCase):
         assert np.allclose(data, self.RX.get_traces())
         del (data)  # this close the file
 
+        # time_axis=0 chunk_mb=10, n_jobs=2
+        self.RX.write_to_binary_dat_format(self.test_dir + 'rec.dat', time_axis=0,
+                                           dtype='float32', chunk_mb=10, n_jobs=2)
+        data = np.memmap(open(self.test_dir + 'rec.dat'), dtype='float32', mode='r', shape=(nb_sample, nb_chan)).T
+        assert np.allclose(data, self.RX.get_traces())
+        del (data)  # this close the file
+
+        # time_axis=1 chunk_mb=10 n_jobs=2
+        self.RX.write_to_binary_dat_format(self.test_dir + 'rec.dat', time_axis=1,
+                                           dtype='float32', chunk_mb=2, n_jobs=2)
+        data = np.memmap(open(self.test_dir + 'rec.dat'), dtype='float32', mode='r', shape=(nb_chan, nb_sample))
+        assert np.allclose(data, self.RX.get_traces())
+        del (data)  # this close the file
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR allows one to use `n_jobs` to speed up writing to binary (e.g. Caching)

A little benchmark:

```
import spikeextractors as se
import spiketoolkit as st
import time

rec, sort = se.example_datasets.toy_example(duration=300, num_channels=32, dumpable=True)
rec = se.MultiRecordingTimeExtractor([rec, rec, rec, rec, rec]) # increase length
rec = st.preprocessing.bandpass_filter(rec)

t_start = time.time()
rec.write_to_binary_dat_format(save_path='test_1_job.dat', chunk_mb=100, n_jobs=1, verbose=True, dtype='int16')
t_stop = time.time()
print(t_stop - t_start) 
# ~77 s

t_start = time.time()
rec.write_to_binary_dat_format(save_path='test_4_job.dat', chunk_mb=100, n_jobs=4, verbose=True, dtype='int16')
t_stop = time.time()
print(t_stop - t_start)
# ~38 s
```