### PR TITLE
Nwb write functions can use timestamps instead of rate

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -26,6 +26,7 @@ except ModuleNotFoundError:
     HAVE_NWB = False
 
 PathType = Union[str, Path, None]
+ArrayType = Union[list, np.ndarray]
 
 
 def check_nwb_install():
@@ -380,7 +381,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                                 name=device_name
                             )
                         )
-                     )
+                    )
                     se.NwbRecordingExtractor.add_devices(recording, nwbfile, metadata=new_device)
                     warnings.warn(f"Device \'{device_name}\' not detected in "
                                   "attempted link to electrode group! Automatically generating.")
@@ -563,7 +564,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         # property 'gain' should not be in the NWB electrodes_table
         # property 'brain_area' of RX channels corresponds to 'location' of NWB electrodes
         channel_prop_names = set(recording.get_shared_channel_property_names()) - set(nwbfile.electrodes.colnames) \
-            - set(['gain', 'location'])
+                             - set(['gain', 'location'])
         for channel_prop_name in channel_prop_names:
             for channel_id in recording.get_channel_ids():
                 val = recording.get_channel_property(channel_id, channel_prop_name)
@@ -582,7 +583,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
 
     @staticmethod
     def add_electrical_series(recording: se.RecordingExtractor, nwbfile=None, metadata: dict = None,
-                              buffer_mb: int = 500):
+                              buffer_mb: int = 500, timestamps: ArrayType = None):
         """
         Auxiliary static method for nwbextractor.
 
@@ -601,6 +602,8 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         buffer_mb: int (optional, defaults to 500MB)
             maximum amount of memory (in MB) to use per iteration of the
             DataChunkIterator (requires traces to be memmap objects)
+        timestamps: array-like
+            If provided, the timestamps are saved as the ElectricalSeries timestamps. (default=None)
 
         Missing keys in an element of metadata['Ecephys']['ElectrodeGroup'] will be auto-populated with defaults
         whenever possible.
@@ -610,6 +613,10 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         assert buffer_mb > 10, "'buffer_mb' should be at least 10MB to ensure data can be chunked!"
         if not nwbfile.electrodes:
             se.NwbRecordingExtractor.add_electrodes(recording, nwbfile, metadata)
+        if timestamps is not None:
+            assert len(timestamps) == recording.get_num_frames(), "Number of 'timestamps' differs from number of " \
+                                                                  "'frames'"
+
         defaults = dict(
             name="ElectricalSeries",
             description="no description"
@@ -661,6 +668,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                     for id in channels_ids:
                         data = recording.get_traces(channel_ids=[id]).flatten()
                         yield data
+
                 ephys_data = H5DataIO(
                     DataChunkIterator(
                         data=data_generator(
@@ -672,19 +680,34 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                     ),
                     compression='gzip'
                 )
-            nwbfile.add_acquisition(
-                ElectricalSeries(
-                    name=es_name,
-                    data=ephys_data,
-                    electrodes=electrode_table_region,
-                    starting_time=recording.frame_to_time(0),
-                    rate=recording.get_sampling_frequency(),
-                    conversion=scalar_conversion,
-                    channel_conversion=channel_conversion,
-                    comments='Generated from SpikeInterface::NwbRecordingExtractor',
-                    description=metadata['Ecephys']['ElectricalSeries'].get('description', defaults['description'])
+            if timestamps is not None:
+                nwbfile.add_acquisition(
+                    ElectricalSeries(
+                        name=es_name,
+                        data=ephys_data,
+                        electrodes=electrode_table_region,
+                        starting_time=recording.frame_to_time(0),
+                        timestamps=timestamps,
+                        conversion=scalar_conversion,
+                        channel_conversion=channel_conversion,
+                        comments='Generated from SpikeInterface::NwbRecordingExtractor',
+                        description=metadata['Ecephys']['ElectricalSeries'].get('description', defaults['description'])
+                    )
                 )
-            )
+            else:
+                nwbfile.add_acquisition(
+                    ElectricalSeries(
+                        name=es_name,
+                        data=ephys_data,
+                        electrodes=electrode_table_region,
+                        starting_time=recording.frame_to_time(0),
+                        rate=recording.get_sampling_frequency(),
+                        conversion=scalar_conversion,
+                        channel_conversion=channel_conversion,
+                        comments='Generated from SpikeInterface::NwbRecordingExtractor',
+                        description=metadata['Ecephys']['ElectricalSeries'].get('description', defaults['description'])
+                    )
+                )
 
     @staticmethod
     def add_epochs(recording: se.RecordingExtractor, nwbfile=None,
@@ -692,7 +715,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         '''
         Auxiliary static method for nwbextractor.
         Adds epochs from recording object to nwbfile object.
-        
+
         Parameters
         ----------
         recording: RecordingExtractor
@@ -732,7 +755,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         Auxiliary static method for nwbextractor.
         Adds all recording related information from recording object and metadata
         to the nwbfile object.
-        
+
         Parameters
         ----------
         recording: RecordingExtractor
@@ -781,12 +804,12 @@ class NwbRecordingExtractor(se.RecordingExtractor):
 
     @staticmethod
     def write_recording(recording: se.RecordingExtractor, save_path: PathType = None,
-                        nwbfile=None, metadata: dict = None):
+                        nwbfile=None, timestamps: ArrayType = None, metadata: dict = None):
         '''
         Writes all recording related information from recording object and metadata
         to either a saved nwbfile (with save_path specified) or directly to an
         nwbfile object (if nwbfile specified).
-        
+
         Parameters
         ----------
         recording: RecordingExtractor
@@ -800,6 +823,8 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                 my_recording_extractor, my_nwbfile
             )
             will result in the appropriate changes to the my_nwbfile object.
+        timestamps: array-like
+            If provided, the timestamps in seconds to be saved as the ElectricalSeries timestamps. (default=None)
         metadata: dict
             metadata info for constructing the nwb file (optional). Should be
             of the format
@@ -980,7 +1005,7 @@ class NwbSortingExtractor(se.SortingExtractor):
 
     @staticmethod
     def write_units(sorting: se.SortingExtractor, nwbfile,
-                    property_descriptions: dict):
+                    property_descriptions: dict, timestamps: ArrayType = None):
         '''
         Helper function for write_sorting.
         '''
@@ -1052,7 +1077,13 @@ class NwbSortingExtractor(se.SortingExtractor):
             for unit_id in unit_ids:
                 unit_kwargs = {}
                 # spike trains withinin the SortingExtractor object are not scaled by sampling frequency
-                spkt = sorting.get_unit_spike_train(unit_id=unit_id) / fs
+                if timestamps is not None:
+                    spike_train_frames = sorting.get_unit_spike_train(unit_id=unit_id)
+                    assert spike_train_frames[-1] < len(timestamps), "Number of 'timestamps' differs from number of " \
+                                                                     "'frames'"
+                    spkt = np.array(timestamps)[spike_train_frames]
+                else:
+                    spkt = sorting.get_unit_spike_train(unit_id=unit_id) / fs
                 for pr in all_properties:
                     if pr not in skip_properties:
                         if pr in sorting.get_unit_property_names(unit_id):
@@ -1148,7 +1179,7 @@ class NwbSortingExtractor(se.SortingExtractor):
 
     @staticmethod
     def write_sorting(sorting: se.SortingExtractor, save_path: PathType = None, nwbfile=None,
-                      property_descriptions: dict = None, **nwbfile_kwargs):
+                      property_descriptions: dict = None, timestamps: ArrayType = None, **nwbfile_kwargs):
         '''
         Parameters
         ----------
@@ -1167,6 +1198,9 @@ class NwbSortingExtractor(se.SortingExtractor):
             For each key in this dictionary which matches the name of a unit
             property in sorting, adds the value as a description to that
             custom unit column.
+        timestamps: array-like
+            If provided, the timestamps in seconds or the assiciated RecordingExtractor to be saved as the unit
+            timestamps. (default=None)
         nwbfile_kwargs: dict
             Information for constructing the nwb file (optional).
             Only used if no nwbfile exists at the save_path, and no nwbfile
@@ -1197,4 +1231,4 @@ class NwbSortingExtractor(se.SortingExtractor):
                 io.write(nwbfile)
         else:
             assert isinstance(nwbfile, NWBFile), "'nwbfile' should be of type pynwb.NWBFile"
-            se.NwbSortingExtractor.write_units(sorting, nwbfile, property_descriptions)
+            se.NwbSortingExtractor.write_units(sorting, nwbfile, property_descriptions, timestamps)

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -103,37 +103,37 @@ class RecordingExtractor(ABC, BaseExtractor):
     def get_dtype(self):
         return self.get_traces(channel_ids=[self.get_channel_ids()[0]], start_frame=0, end_frame=1).dtype
 
-    def frame_to_time(self, frame):
-        '''This function converts a user-inputted frame index to a time with units of seconds.
+    def frame_to_time(self, frames):
+        '''This function converts user-inputted frame indexes to times with units of seconds.
 
         Parameters
         ----------
-        frame: float
-            The frame to be converted to a time
+        frames: float or array-like
+            The frame or frames to be converted to times
 
         Returns
         -------
-        time: float
-            The corresponding time in seconds
+        times: float or array-like
+            The corresponding times in seconds
         '''
         # Default implementation
-        return np.round(frame / self.get_sampling_frequency(), 6)
+        return np.round(frames / self.get_sampling_frequency(), 6)
 
-    def time_to_frame(self, time):
-        '''This function converts a user-inputted time (in seconds) to a frame index.
+    def time_to_frame(self, times):
+        '''This function converts a user-inputted times (in seconds) to a frame indexes.
 
         Parameters
         -------
-        time: float
-            The time (in seconds) to be converted to frame index
+        times: float or array-like
+            The times (in seconds) to be converted to frame indexes
 
         Returns
         -------
-        frame: float
-            The corresponding frame index
+        frames: float or array-like
+            The corresponding frame indexes
         '''
         # Default implementation
-        return np.round(time * self.get_sampling_frequency()).astype('int64')
+        return np.round(times * self.get_sampling_frequency()).astype('int64')
 
     def get_snippets(self, reference_frames, snippet_len, channel_ids=None):
         '''This function returns data snippets from the given channels that


### PR DESCRIPTION
- Also changed the docstrings for `time_to_frame` and `frame_to_time` as they also accept an array as input 