### PR TITLE
Extend neuroscope recording to lfp

### DIFF
--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -41,6 +41,7 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
     def __init__(self, file_path: PathType):
         assert HAVE_LXML, self.installation_mesg
         file_path = Path(file_path)
+        print(file_path)
         assert file_path.is_file() and file_path.suffix in [".dat", ".eeg"], \
             "file_path must lead to a .dat or .eeg file!"
 

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -41,7 +41,6 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
     def __init__(self, file_path: PathType):
         assert HAVE_LXML, self.installation_mesg
         file_path = Path(file_path)
-        print(file_path)
         assert file_path.is_file() and file_path.suffix in [".dat", ".eeg"], \
             "file_path must lead to a .dat or .eeg file!"
 

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -667,7 +667,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                             recording=recording,
                             channels_ids=channel_ids
                         ),
-                        iter_axis=1,  # nwb standard is time as zero axis,
+                        iter_axis=1,  # nwb standard is time as zero axis
                         maxshape=(recording.get_num_frames(), recording.get_num_channels())
                     ),
                     compression='gzip'

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -657,7 +657,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                 )
             else:
                 def data_generator(recording, channels_ids):
-                    #  generates data chunks for iterator
+                    # generates data chunks for iterator
                     for id in channels_ids:
                         data = recording.get_traces(channel_ids=[id]).flatten()
                         yield data

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -747,7 +747,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             nwbfile.add_acquisition(ElectricalSeries(**eseries_kwargs))
         else:
             eseries_kwargs.update(
-                description=metadata['Ecephys']['ElectricalSeries'].get('description', lfp_defaults['description'])
+                description=metadata['Ecephys']['LFPElectricalSeries'].get('description', lfp_defaults['description'])
             )
             ecephys_mod.data_interfaces['LFP'].add_electrical_series(ElectricalSeries(**eseries_kwargs))
 

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -657,8 +657,10 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                 metadata['Ecephys'].update(
                     LFPElectricalSeries=dict(lfp_defaults)
                 )
-        assert isinstance(metadata['Ecephys']['ElectricalSeries'], dict) \
-            or isinstance(metadata['Ecephys']['LFPElectricalSeries'], dict), \
+        assert ('ElectricalSeries' in metadata['Ecephys']
+                and isinstance(metadata['Ecephys']['ElectricalSeries'], dict)) \
+            or ('LFPElectricalSeries' in metadata['Ecephys']
+                and isinstance(metadata['Ecephys']['LFPElectricalSeries'], dict)), \
             "Expected either metadata['Ecephys']['ElectricalSeries'] or metadata['Ecephys']['LFPElectricalSeries'] " \
             "to be a dictionary!"
 

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -659,9 +659,8 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                 )
         assert isinstance(metadata['Ecephys']['ElectricalSeries'], dict) \
             or isinstance(metadata['Ecephys']['LFPElectricalSeries'], dict), \
-            "Expected metadata['Ecephys']['ElectricalSeries'] to be a dictionary!"
-        assert isinstance(metadata['Ecephys']['LFPElectricalSeries'], dict), \
-            "Expected metadata['Ecephys']['LFPElectricalSeries'] to be a dictionary!"
+            "Expected either metadata['Ecephys']['ElectricalSeries'] or metadata['Ecephys']['LFPElectricalSeries'] " \
+            "to be a dictionary!"
 
         if not write_as_lfp:
             es_name = metadata['Ecephys']['ElectricalSeries'].get('name', raw_defaults['name'])

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -930,6 +930,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                         recording=recording,
                         nwbfile=nwbfile,
                         metadata=metadata,
+                        use_timestamps=use_timestamps,
                         write_as_lfp=write_as_lfp
                     )
 
@@ -1279,10 +1280,19 @@ class NwbSortingExtractor(se.SortingExtractor):
                               'session_start_time': datetime.now()}
                     kwargs.update(**nwbfile_kwargs)
                     nwbfile = NWBFile(**kwargs)
-
-                se.NwbSortingExtractor.write_units(sorting, nwbfile, property_descriptions)
+                se.NwbSortingExtractor.write_units(
+                    sorting=sorting,
+                    nwbfile=nwbfile,
+                    property_descriptions=property_descriptions,
+                    timestamps=timestamps
+                )
 
                 io.write(nwbfile)
         else:
             assert isinstance(nwbfile, NWBFile), "'nwbfile' should be of type pynwb.NWBFile"
-            se.NwbSortingExtractor.write_units(sorting, nwbfile, property_descriptions, timestamps)
+            se.NwbSortingExtractor.write_units(
+                    sorting=sorting,
+                    nwbfile=nwbfile,
+                    property_descriptions=property_descriptions,
+                    timestamps=timestamps
+            )


### PR DESCRIPTION
@bendichter @alejoe91 Extends the `NeuroscopeRecordingExtractor` to be used on the nearly identically formatted `.eeg` files for use in the nwb-conversion-tools LFP data interfaces.

Also minor refactoring of `NwbRecordingExtractor.add_electrical_series`.