### PR TITLE
Add neuroscope multirecordingtime extractor

### DIFF
--- a/spikeextractors/extractorlist.py
+++ b/spikeextractors/extractorlist.py
@@ -26,8 +26,8 @@ from .extractors.neoextractors import (PlexonRecordingExtractor, PlexonSortingEx
                                        NeuralynxRecordingExtractor, NeuralynxSortingExtractor,
                                        BlackrockRecordingExtractor, BlackrockSortingExtractor,
                                        MCSRawRecordingExtractor)
-from .extractors.neuroscopeextractors import NeuroscopeRecordingExtractor, NeuroscopeSortingExtractor,\
-    NeuroscopeMultiSortingExtractor
+from .extractors.neuroscopeextractors import NeuroscopeRecordingExtractor, NeuroscopeMultiRecordingTimeExtractor, \
+    NeuroscopeSortingExtractor, NeuroscopeMultiSortingExtractor
 from .extractors.waveclussortingextractor import WaveClusSortingExtractor
 from .extractors.yassextractors import YassSortingExtractor
 from .extractors.combinatosortingextractor import CombinatoSortingExtractor
@@ -53,6 +53,7 @@ recording_extractor_full_list = [
     SHYBRIDRecordingExtractor,
     NIXIORecordingExtractor,
     NeuroscopeRecordingExtractor,
+    NeuroscopeMultiRecordingTimeExtractor,
     CEDRecordingExtractor,
     
     # neo based

--- a/spikeextractors/extractors/neuroscopeextractors/__init__.py
+++ b/spikeextractors/extractors/neuroscopeextractors/__init__.py
@@ -1,1 +1,2 @@
-from .neuroscopeextractors import NeuroscopeRecordingExtractor,NeuroscopeSortingExtractor,NeuroscopeMultiSortingExtractor
+from .neuroscopeextractors import NeuroscopeRecordingExtractor, NeuroscopeMultiRecordingTimeExtractor
+from .neuroscopeextractors import NeuroscopeSortingExtractor, NeuroscopeMultiSortingExtractor

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -160,7 +160,6 @@ class NeuroscopeMultiRecordingTimeExtractor(MultiRecordingTimeExtractor):
         assert any(recording_files), "The folder_path must lead to at least one .dat file!"
 
         recordings = [NeuroscopeRecordingExtractor(file_path=x) for x in recording_files]
-
         MultiRecordingTimeExtractor.__init__(self, recordings=recordings)
 
         self._kwargs = {'folder_path': str(folder_path.absolute())}

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -1,10 +1,11 @@
-from spikeextractors import RecordingExtractor, SortingExtractor, MultiSortingExtractor
+from spikeextractors import RecordingExtractor, MultiRecordingTimeExtractor, SortingExtractor, MultiSortingExtractor
 from spikeextractors.extractors.bindatrecordingextractor import BinDatRecordingExtractor
 import numpy as np
 from pathlib import Path
 from spikeextractors.extraction_tools import check_valid_unit_id, get_sub_extractors_by_property
 from typing import Union
 import re
+import warnings
 
 try:
     from lxml import etree as et
@@ -129,6 +130,128 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
         et.ElementTree(xml_root).write(str(save_xml_filepath.absolute()), pretty_print=True)
 
         recording.write_to_binary_dat_format(recording_filepath, dtype=dtype, **write_binary_kwargs)
+
+
+class NeuroscopeMultiRecordingTimeExtractor(MultiRecordingTimeExtractor):
+    """
+    Extracts raw neural recordings from several binary .dat files in the neuroscope format.
+
+    The recording extractor always returns channel IDs starting from 0.
+
+    The recording data will always be returned in the shape of (num_channels,num_frames).
+
+    Parameters
+    ----------
+    folder_path : PathType
+        Path to the .dat files to be extracted.
+    """
+
+    extractor_name = "NeuroscopeMultiRecordingTimeExtractor"
+    installed = HAVE_LXML
+    is_writable = True
+    mode = "folder"
+    installation_mesg = "Please install lxml to use this extractor!"
+
+    def __init__(self, folder_path: PathType):
+        assert HAVE_LXML, self.installation_mesg
+
+        folder_path = Path(folder_path)
+        recording_files = [x for x in folder_path.iterdir() if x.is_file() and x.suffix == ".dat"]
+        assert any(recording_files), "The folder_path must lead to at least one .dat file!"
+
+        recordings = [NeuroscopeRecordingExtractor(file_path=x) for x in recording_files]
+
+        MultiRecordingTimeExtractor.__init__(self, recordings=recordings)
+
+        self._kwargs = {'folder_path': str(folder_path.absolute())}
+
+    @staticmethod
+    def write_recording(recording: Union[MultiRecordingTimeExtractor, RecordingExtractor],
+                        save_path: PathType, dtype: DtypeType = None, **write_binary_kwargs):
+        """
+        Convert and save the recording extractor to Neuroscope format.
+
+        Parameters
+        ----------
+        recording: MultiRecordingTimeExtractor or RecordingExtractor
+            The recording extractor to be converted and saved.
+        save_path: str
+            Path to desired target folder. The name of the files will be the same as the final directory.
+        dtype: dtype
+            Optional. Data type to be used in writing; must be int16 or int32 (default).
+                      Will throw a warning if stored recording type from get_traces() does not match.
+        **write_binary_kwargs: keyword arguments for write_to_binary_dat_format function
+            - chunk_size
+            - chunk_mb
+        """
+        save_path = Path(save_path)
+        save_path.mkdir(parents=True, exist_ok=True)
+
+        if save_path.suffix == "":
+            recording_name = save_path.name
+        else:
+            recording_name = save_path.stem
+
+        xml_name = recording_name
+        save_xml_filepath = save_path / f"{xml_name}.xml"
+        if save_xml_filepath.is_file():
+            raise FileExistsError(f"{save_xml_filepath} already exists!")
+
+        recording_dtype = str(recording.get_dtype())
+        int_loc = recording_dtype.find("int")
+        recording_n_bits = recording_dtype[(int_loc + 3):(int_loc + 5)]
+
+        valid_int_types = ["16", "32"]
+        if dtype is None:
+            if int_loc != -1 and recording_n_bits in valid_int_types:
+                n_bits = recording_n_bits
+            else:
+                warnings.warn("Recording data type must be int16 or int32! Defaulting to int32.")
+                n_bits = "32"
+            dtype = f"int{n_bits}"
+        else:
+            dtype = str(dtype)
+            int_loc = dtype.find('int')
+            assert int_loc != -1, "Data type must be int16 or int32! Non-integer received."
+            n_bits = dtype[(int_loc + 3):(int_loc + 5)]
+            assert n_bits in valid_int_types, "Data type must be int16 or int32!"
+
+        xml_root = et.Element('xml')
+        et.SubElement(xml_root, 'acquisitionSystem')
+        et.SubElement(xml_root.find('acquisitionSystem'), 'nBits')
+        et.SubElement(xml_root.find('acquisitionSystem'), 'nChannels')
+        et.SubElement(xml_root.find('acquisitionSystem'), 'samplingRate')
+        xml_root.find('acquisitionSystem').find('nBits').text = n_bits
+        xml_root.find('acquisitionSystem').find('nChannels').text = str(recording.get_num_channels())
+        xml_root.find('acquisitionSystem').find('samplingRate').text = str(recording.get_sampling_frequency())
+        et.ElementTree(xml_root).write(str(save_xml_filepath.absolute()), pretty_print=True)
+
+        if isinstance(recording, MultiRecordingTimeExtractor):
+            for n, record in enumerate(recording.recordings):
+                epoch_id = str(n).zfill(2)  # Neuroscope seems to zero-pad length 2
+                record.write_to_binary_dat_format(
+                    save_path=save_path / f"{recording_name}-{epoch_id}.dat",
+                    dtype=dtype,
+                    **write_binary_kwargs
+                )
+
+        elif isinstance(recording, RecordingExtractor):
+            recordings = [recording.get_epoch(epoch_name=epoch_name) for epoch_name in recording.get_epoch_names()]
+
+            if len(recordings) == 0:
+                recording.write_to_binary_dat_format(
+                    save_path=save_path / f"{recording_name}.dat",
+                    dtype=dtype,
+                    **write_binary_kwargs
+                )
+            else:
+                for n, subrecording in enumerate(recordings):
+                    epoch_id = str(n).zfill(2)  # Neuroscope seems to zero-pad length 2
+                    subrecording.write_to_binary_dat_format(
+                        save_path=save_path / f"{recording_name}-{epoch_id}.dat",
+                        dtype=dtype,
+                        **write_binary_kwargs
+                    )
 
 
 class NeuroscopeSortingExtractor(SortingExtractor):

--- a/spikeextractors/tests/test_extractors.py
+++ b/spikeextractors/tests/test_extractors.py
@@ -527,6 +527,16 @@ class TestExtractors(unittest.TestCase):
         check_recordings_equal(self.RX, RX_ns)
         check_dumping(RX_ns)
 
+        # NeuroscopeMultiRecordingTimeExtractor tests
+        nscope_dir = Path(self.test_dir) / "neuroscope_rec2"
+        dat_file = nscope_dir / "neuroscope_rec2.dat"
+        RX_multirecording = se.MultiRecordingTimeExtractor(recordings=[self.RX, self.RX])
+        se.NeuroscopeMultiRecordingTimeExtractor.write_recording(recording=RX_multirecording, save_path=nscope_dir)
+        RX_mre = se.NeuroscopeMultiRecordingTimeExtractor(folder_path=nscope_dir)
+        check_recording_return_types(RX_mre)
+        check_recordings_equal(RX_multirecording, RX_mre)
+        check_dumping(RX_mre)
+
         # NeuroscopeSortingExtractor tests
         nscope_dir = Path(self.test_dir) / 'neuroscope_sort0'
         sort_name = 'neuroscope_sort0'
@@ -563,7 +573,7 @@ class TestExtractors(unittest.TestCase):
 
         # Tests for the NeuroscopeMultiSortingExtractor
         nscope_dir = Path(self.test_dir) / 'neuroscope_sort1'
-        SX_multisorting = se.MultiSortingExtractor(sortings=[self.SX, self.SX])  # re-using same SX for simplicity
+        SX_multisorting = se.MultiSortingExtractor(sortings=[self.SX, self.SX])
         se.NeuroscopeMultiSortingExtractor.write_sorting(SX_multisorting, nscope_dir)
         SX_neuroscope_mse = se.NeuroscopeMultiSortingExtractor(nscope_dir)
         check_sorting_return_types(SX_neuroscope_mse)


### PR DESCRIPTION
@bendichter @alejoe91 The PeyracheA dataset from the Buzsaki lab reports some raw data broken up by chronological epochs. Considering this the structure used there as standard for the Neuroscope format, this class uses the `MultiRecordingTimeInterface` to  read in these multiple `.dat` files and combine them into a single extractor for conversion purposes. Highly analogous to the `NeuroscopeMultiSorting` extractor.