### PR TITLE
Fix check module for nwb import

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -130,7 +130,7 @@ def list_get(l, idx, default):
         return default
 
 
-def check_module(nwbfile: pynwb.NWBFile, name: str, description: str = None):
+def check_module(nwbfile, name: str, description: str = None):
     """
     Check if processing module exists. If not, create it. Then return module.
 
@@ -144,6 +144,7 @@ def check_module(nwbfile: pynwb.NWBFile, name: str, description: str = None):
     -------
     pynwb.module
     """
+    assert isinstance(nwbfile, pynwb.NWBFile), "'nwbfile should be an instance of pynwb.NWBFile'"
     if name in nwbfile.modules:
         return nwbfile.modules[name]
     else:

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -144,7 +144,7 @@ def check_module(nwbfile, name: str, description: str = None):
     -------
     pynwb.module
     """
-    assert isinstance(nwbfile, pynwb.NWBFile), "'nwbfile should be an instance of pynwb.NWBFile'"
+    assert isinstance(nwbfile, pynwb.NWBFile), "'nwbfile' should be of type pynwb.NWBFile"
     if name in nwbfile.modules:
         return nwbfile.modules[name]
     else:


### PR DESCRIPTION
@CodyCBakerPhD the `nwbfile: pynwb.NWBFile` in the `check_module` function is messing up downstream tests because `pynwb` is not a requirement. 