### PR TITLE
Fix h5 unsorted channel_ids in get_traces

### DIFF
--- a/spikeextractors/extractors/maxoneextractors/maxoneextractors.py
+++ b/spikeextractors/extractors/maxoneextractors/maxoneextractors.py
@@ -103,9 +103,10 @@ class MaxOneRecordingExtractor(RecordingExtractor):
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         if np.array(channel_ids).size > 1:
             if np.any(np.diff(channel_ids) < 0):
-                sorted_idx = np.argsort(channel_ids)
-                recordings = self._signals[np.sort(channel_ids), start_frame:end_frame]
-                return (recordings[sorted_idx] * self._lsb).astype('float')
+                sorted_channel_ids = np.sort(channel_ids)
+                sorted_idx = np.array([list(sorted_channel_ids).index(ch) for ch in channel_ids])
+                recordings = (self._signals[sorted_channel_ids, start_frame:end_frame] * self._lsb).astype('float32')
+                return recordings[sorted_idx]
             else:
                 return (self._signals[np.array(channel_ids), start_frame:end_frame] * self._lsb).astype('float32')
         else:

--- a/spikeextractors/extractors/mcsh5recordingextractor/mcsh5recordingextractor.py
+++ b/spikeextractors/extractors/mcsh5recordingextractor/mcsh5recordingextractor.py
@@ -83,8 +83,9 @@ class MCSH5RecordingExtractor(RecordingExtractor):
 
         if np.array(channel_idxs).size > 1:
             if np.any(np.diff(channel_idxs) < 0):
-                sorted_idx = np.argsort(channel_idxs)
-                recordings = stream.get('ChannelData')[np.sort(channel_idxs), start_frame:end_frame]
+                sorted_channel_ids = np.sort(channel_idxs)
+                sorted_idx = np.array([list(sorted_channel_ids).index(ch) for ch in channel_idxs])
+                recordings = stream.get('ChannelData')[sorted_channel_ids, start_frame:end_frame]
                 return recordings[sorted_idx] * conv
             else:
                 return stream.get('ChannelData')[np.sort(channel_idxs), start_frame:end_frame] * conv

--- a/spikeextractors/extractors/mea1kextractors/mea1kextractors.py
+++ b/spikeextractors/extractors/mea1kextractors/mea1kextractors.py
@@ -184,9 +184,10 @@ class Mea1kRecordingExtractor(RecordingExtractor):
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         if np.array(channel_ids).size > 1:
             if np.any(np.diff(channel_ids) < 0):
-                sorted_idx = np.argsort(channel_ids)
-                recordings = self._signals[np.sort(channel_ids), start_frame:end_frame]
-                return recordings[sorted_idx].astype('float')
+                sorted_channel_ids = np.sort(channel_ids)
+                sorted_idx = np.array([list(sorted_channel_ids).index(ch) for ch in channel_ids])
+                recordings = (self._signals[sorted_channel_ids, start_frame:end_frame] * self._lsb).astype('float32')
+                return recordings[sorted_idx]
             else:
                 return (self._signals[np.array(channel_ids), start_frame:end_frame] * self._lsb).astype('float32')
         else:

--- a/spikeextractors/extractors/mearecextractors/mearecextractors.py
+++ b/spikeextractors/extractors/mearecextractors/mearecextractors.py
@@ -77,8 +77,9 @@ class MEArecRecordingExtractor(RecordingExtractor):
     @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
         if np.any(np.diff(channel_ids) < 0):
-            sorted_idx = np.argsort(channel_ids)
-            recordings = self._recordings[start_frame:end_frame, np.sort(channel_ids)]
+            sorted_channel_ids = np.sort(channel_ids)
+            sorted_idx = np.array([list(sorted_channel_ids).index(ch) for ch in channel_ids])
+            recordings = self._recordings[start_frame:end_frame, sorted_channel_ids]
             return np.array(recordings[sorted_idx]).transpose()
         else:
             if sorted(channel_ids) == channel_ids and np.all(np.diff(channel_ids) == 1):

--- a/spikeextractors/extractors/mearecextractors/mearecextractors.py
+++ b/spikeextractors/extractors/mearecextractors/mearecextractors.py
@@ -80,11 +80,11 @@ class MEArecRecordingExtractor(RecordingExtractor):
             sorted_channel_ids = np.sort(channel_ids)
             sorted_idx = np.array([list(sorted_channel_ids).index(ch) for ch in channel_ids])
             recordings = self._recordings[start_frame:end_frame, sorted_channel_ids]
-            return np.array(recordings[sorted_idx]).transpose()
+            return np.array(recordings[:, sorted_idx]).T
         else:
             if sorted(channel_ids) == channel_ids and np.all(np.diff(channel_ids) == 1):
                 channel_ids = slice(channel_ids[0], channel_ids[0] + len(channel_ids))
-            return np.array(self._recordings[start_frame:end_frame, channel_ids]).transpose()
+            return np.array(self._recordings[start_frame:end_frame, channel_ids]).T
         
     @staticmethod
     def write_recording(recording, save_path, check_suffix=True):

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -289,7 +289,6 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                 # to be indexed out of order
                 sorted_channel_ids = np.sort(channel_ids)
                 sorted_idx = np.array([list(sorted_channel_ids).index(ch) for ch in channel_ids])
-                print(sorted_idx)
                 recordings = es.data[start_frame:end_frame, sorted_channel_ids].T
                 traces = recordings[sorted_idx, :]
             else:

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -287,8 +287,10 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             if np.array(channel_ids).size > 1 and np.any(np.diff(channel_ids) < 0):
                 # get around h5py constraint that it does not allow datasets
                 # to be indexed out of order
-                sorted_idx = np.argsort(channel_inds)
-                recordings = es.data[start_frame:end_frame, np.sort(channel_inds)].T
+                sorted_channel_ids = np.sort(channel_ids)
+                sorted_idx = np.array([list(sorted_channel_ids).index(ch) for ch in channel_ids])
+                print(sorted_idx)
+                recordings = es.data[start_frame:end_frame, sorted_channel_ids].T
                 traces = recordings[sorted_idx, :]
             else:
                 traces = es.data[start_frame:end_frame, channel_inds].T


### PR DESCRIPTION
**IMPORTANT**

@samuelgarcia @magland @colehurwitz @mhhennig @bendichter 

Hi guys, found this nasty bug in h5-based extractors. 

The bug occurs when traces are retrieved from h5-based extractors (MEArec, NWB, MCSH5, Mea1k, MaxOne) using a subset of **UNSORTED** `channel_ids`, which fortunately it's not a common use case.

I found the bug because I had to sort and concatenate several recordings with different channel maps and the traces were looking weird. 

All of our benchmarks are fine because we always use all channels.
