### PR TITLE
small fixes to write methods for nwb recording and sorting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ jobs:
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 
 install:
-- pip install h5py==2.10.0 mountainlab_pytools pynwb==1.3.3 pyopenephys kbucket MEArec>=1.5.0 shybrid exdir ruamel.yaml nixio neo>=0.8 hdf5storage bs4 lxml
-- pip install numpy>=1.16.5
+- pip install pandas==1.1.5 h5py==2.10.0 mountainlab_pytools pynwb==1.3.3 pyopenephys kbucket MEArec>=1.5.0 shybrid exdir ruamel.yaml nixio neo>=0.8 hdf5storage bs4 lxml
 - pip install .
 - pip install pytest==3.6
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jobs:
 
 install:
 - pip install h5py==2.10.0 mountainlab_pytools pynwb==1.3.3 pyopenephys kbucket MEArec>=1.5.0 shybrid exdir ruamel.yaml nixio neo>=0.8 hdf5storage bs4 lxml
+- pip install numpy>=1.16.5
 - pip install .
 - pip install pytest==3.6
 script: pytest

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -1095,9 +1095,9 @@ class NwbSortingExtractor(se.SortingExtractor):
                 warnings.warn(f"Description for property {pr} not found in property_descriptions. "
                               f"Setting description to 'no description'")
 
+        skip_properties = ["mda_max_channel"]
         if nwbfile.units is None:
             # Check that array properties have the same shape across units
-            skip_properties = []
             property_shapes = dict()
             for pr in all_properties:
                 shapes = []

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -733,7 +733,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         if not use_timestamps:
             eseries_kwargs.update(
                 starting_time=recording.frame_to_time(0),
-                rate=recording.get_sampling_frequency()
+                rate=float(recording.get_sampling_frequency())
             )
         else:
             eseries_kwargs.update(
@@ -1125,14 +1125,16 @@ class NwbSortingExtractor(se.SortingExtractor):
                     skip_properties.append(pr)
 
             for pr in all_properties:
-                # Special case of setting max_electrodes requires a table to be
-                # passed to become a dynamic table region
+                # Special case of setting max_electrodes requires a table to be passed to become a dynamic table region
                 if pr not in skip_properties:
                     if pr in ['max_channel', 'max_electrode']:
                         if nwbfile.electrodes is None:
-                            warnings.warn("Attempted to make a custom column for max_channel "
-                                          "or max_electrode, but there are no electrodes to reference! "
-                                          "Column will not be added.")
+                            warnings.warn("Attempted to make a custom column for max_channelor max_electrode, but "
+                                          "there are no electrodes to reference! Reference table will not be added.")
+                            nwbfile.add_unit_column(
+                                name=pr,
+                                description=property_descriptions.get(pr, "No description.")
+                            )
                         else:
                             nwbfile.add_unit_column(
                                 name=pr,

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -700,7 +700,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             scalar_conversion = 1.
             channel_conversion = gains * 1e-6
 
-        if isinstance(recording.get_traces(), np.memmap):
+        if isinstance(recording.get_traces(end_frame=5), np.memmap):
             n_bytes = np.dtype(recording.get_dtype()).itemsize
             buffer_size = int(buffer_mb * 1e6) // (recording.get_num_channels() * n_bytes)
             ephys_data = DataChunkIterator(
@@ -1133,7 +1133,8 @@ class NwbSortingExtractor(se.SortingExtractor):
                 property_shapes[pr] = shapes
 
             for pr in property_shapes.keys():
-                if not np.all([elem == property_shapes[pr][0] for elem in property_shapes[pr]]):
+                elems = [elem for elem in property_shapes[pr] if not np.isnan(elem)]
+                if not np.all([elem == elems[0] for elem in elems]):
                     print(f"Skipping property '{pr}' because it has variable size across units.")
                     skip_properties.append(pr)
 

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -1076,6 +1076,8 @@ class NwbSortingExtractor(se.SortingExtractor):
         """Auxilliary function for write_sorting."""
         unit_ids = sorting.get_unit_ids()
         fs = sorting.get_sampling_frequency()
+        if fs is None:
+            raise ValueError("Writing a SortingExtractor to an NWBFile requires a known sampling frequency!")
 
         all_properties = set()
         all_features = set()

--- a/spikeextractors/tests/test_extractors.py
+++ b/spikeextractors/tests/test_extractors.py
@@ -149,10 +149,10 @@ class TestExtractors(unittest.TestCase):
         print(self.RX.get_channel_locations())
         self.assertTrue(np.array_equal(self.RX3.get_channel_locations(),
                                        self.RX2.get_channel_locations()))
-        self.RX3.set_channel_groups(groups=[1],channel_ids=[1])
-        self.assertEqual(self.RX3.get_channel_groups(channel_ids=[1]),1)
+        self.RX3.set_channel_groups(groups=[1], channel_ids=[1])
+        self.assertEqual(self.RX3.get_channel_groups(channel_ids=[1]), 1)
         self.RX3.clear_channel_groups()
-        self.assertEqual(self.RX3.get_channel_groups(channel_ids=[1]),0)
+        self.assertEqual(self.RX3.get_channel_groups(channel_ids=[1]), 0)
         self.RX3.set_channel_locations(locations=[[np.nan, np.nan, np.nan]], channel_ids=[1])
         self.assertTrue('location' not in self.RX3.get_shared_channel_property_names())
         self.RX3.set_channel_locations(locations=[[0, 0, 0]], channel_ids=[1])
@@ -450,17 +450,16 @@ class TestExtractors(unittest.TestCase):
         check_dumping(RX_nwb)
 
         del RX_nwb
-        # overwrite
         se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path1, overwrite=True)
         RX_nwb = se.NwbRecordingExtractor(path1)
         check_recording_return_types(RX_nwb)
         check_recordings_equal(self.RX, RX_nwb)
         check_dumping(RX_nwb)
 
-        # add sorting to existing
-        se.NwbSortingExtractor.write_sorting(sorting=self.SX, save_path=path1)
-        # create new
-        path2 = self.test_dir + '/firings_true.nwb'
+        # append sorting to existing file
+        se.NwbSortingExtractor.write_sorting(sorting=self.SX, save_path=path1, overwrite=False)
+
+        path2 = self.test_dir + "/firings_true.nwb"
         se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path2)
         se.NwbSortingExtractor.write_sorting(sorting=self.SX, save_path=path2)
         SX_nwb = se.NwbSortingExtractor(path2)
@@ -468,14 +467,25 @@ class TestExtractors(unittest.TestCase):
         check_dumping(SX_nwb)
 
         # Test for handling unit property descriptions argument
-        property_descriptions = {'stability': 'this is a description of stability'}
-        se.NwbSortingExtractor.write_sorting(sorting=self.SX, save_path=path1,
-                                             property_descriptions=property_descriptions)
-        # create new
-        se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path2, overwrite=True)
-        se.NwbSortingExtractor.write_sorting(sorting=self.SX, save_path=path2,
-                                             property_descriptions=property_descriptions)
-        SX_nwb = se.NwbSortingExtractor(path2)
+        property_descriptions = dict(stability="This is a description of stability.")
+        se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path1, overwrite=True)
+        se.NwbSortingExtractor.write_sorting(
+            sorting=self.SX,
+            save_path=path1,
+            property_descriptions=property_descriptions
+        )
+        SX_nwb = se.NwbSortingExtractor(path1)
+        check_sortings_equal(self.SX, SX_nwb)
+        check_dumping(SX_nwb)
+
+        # Test for handling unit skip_properties argument
+        se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path1, overwrite=True)
+        se.NwbSortingExtractor.write_sorting(
+            sorting=self.SX,
+            save_path=path1,
+            skip_properties=['stability']
+        )
+        SX_nwb = se.NwbSortingExtractor(path1)
         check_sortings_equal(self.SX, SX_nwb)
         check_dumping(SX_nwb)
 

--- a/spikeextractors/tests/test_extractors.py
+++ b/spikeextractors/tests/test_extractors.py
@@ -32,19 +32,33 @@ class TestExtractors(unittest.TestCase):
         geom = np.random.RandomState(seed=seed).normal(0, 1, (num_channels, 2))
         X = (X * 100).astype(int)
         ttls = np.sort(np.random.permutation(num_frames)[:num_ttls])
+
         RX = se.NumpyRecordingExtractor(timeseries=X, sampling_frequency=sampling_frequency, geom=geom)
-        RX2 = se.NumpyRecordingExtractor(timeseries=X, sampling_frequency=sampling_frequency, geom=geom)
-        RX3 = se.NumpyRecordingExtractor(timeseries=X, sampling_frequency=sampling_frequency, geom=geom)
         RX.set_ttls(ttls)
+        RX.set_channel_locations([0, 0], channel_ids=0)
+        RX.add_epoch("epoch1", 0, 10)
+        RX.add_epoch("epoch2", 10, 20)
+        for i, channel_id in enumerate(RX.get_channel_ids()):
+            RX.set_channel_property(channel_id=channel_id, property_name='shared_channel_prop', value=i)
+
+        RX2 = se.NumpyRecordingExtractor(timeseries=X, sampling_frequency=sampling_frequency, geom=geom)
+        RX2.copy_epochs(RX)
+
+        RX3 = se.NumpyRecordingExtractor(timeseries=X, sampling_frequency=sampling_frequency, geom=geom)
+
         SX = se.NumpySortingExtractor()
+        SX.set_sampling_frequency(sampling_frequency)
         spike_times = [200, 300, 400]
         train1 = np.sort(np.rint(np.random.RandomState(seed=seed).uniform(0, num_frames, spike_times[0])).astype(int))
         SX.add_unit(unit_id=1, times=train1)
         SX.add_unit(unit_id=2, times=np.sort(np.random.RandomState(seed=seed).uniform(0, num_frames, spike_times[1])))
         SX.add_unit(unit_id=3, times=np.sort(np.random.RandomState(seed=seed).uniform(0, num_frames, spike_times[2])))
         SX.set_unit_property(unit_id=1, property_name='stability', value=80)
-        SX.set_sampling_frequency(sampling_frequency)
+        SX.add_epoch("epoch1", 0, 10)
+        SX.add_epoch("epoch2", 10, 20)
+
         SX2 = se.NumpySortingExtractor()
+        SX2.set_sampling_frequency(sampling_frequency)
         spike_times2 = [100, 150, 450]
         train2 = np.rint(np.random.RandomState(seed=seed).uniform(0, num_frames, spike_times2[0])).astype(int)
         SX2.add_unit(unit_id=3, times=train2)
@@ -52,19 +66,14 @@ class TestExtractors(unittest.TestCase):
         SX2.add_unit(unit_id=5, times=np.random.RandomState(seed=seed).uniform(0, num_frames, spike_times2[2]))
         SX2.set_unit_property(unit_id=4, property_name='stability', value=80)
         SX2.set_unit_spike_features(unit_id=3, feature_name='widths', value=np.asarray([3] * spike_times2[0]))
-        RX.set_channel_locations([0, 0], channel_ids=0)
-        RX.add_epoch("epoch1", 0, 10)
-        RX.add_epoch("epoch2", 10, 20)
-        SX.add_epoch("epoch1", 0, 10)
-        SX.add_epoch("epoch2", 10, 20)
-        RX2.copy_epochs(RX)
         SX2.copy_epochs(SX)
         for i, unit_id in enumerate(SX2.get_unit_ids()):
             SX2.set_unit_property(unit_id=unit_id, property_name='shared_unit_prop', value=i)
-            SX2.set_unit_spike_features(unit_id=unit_id, feature_name='shared_unit_feature',
-                                        value=np.asarray([i] * spike_times2[i]))
-        for i, channel_id in enumerate(RX.get_channel_ids()):
-            RX.set_channel_property(channel_id=channel_id, property_name='shared_channel_prop', value=i)
+            SX2.set_unit_spike_features(
+                unit_id=unit_id,
+                feature_name='shared_unit_feature',
+                value=np.asarray([i] * spike_times2[i])
+            )
 
         SX3 = se.NumpySortingExtractor()
         train3 = np.asarray([1, 20, 21, 35, 38, 45, 46, 47])
@@ -478,7 +487,7 @@ class TestExtractors(unittest.TestCase):
         check_sortings_equal(self.SX, SX_nwb)
         check_dumping(SX_nwb)
 
-        # Test for handling unit skip_properties argument
+        # Test for handling skip_properties argument
         se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path1, overwrite=True)
         se.NwbSortingExtractor.write_sorting(
             sorting=self.SX,
@@ -487,6 +496,17 @@ class TestExtractors(unittest.TestCase):
         )
         SX_nwb = se.NwbSortingExtractor(path1)
         check_sortings_equal(self.SX, SX_nwb)
+        check_dumping(SX_nwb)
+
+        # Test for handling skip_features argument
+        se.NwbRecordingExtractor.write_recording(recording=self.RX, save_path=path1, overwrite=True)
+        se.NwbSortingExtractor.write_sorting(
+            sorting=self.SX2,
+            save_path=path1,
+            skip_features=['widths']
+        )
+        SX_nwb = se.NwbSortingExtractor(path1)
+        check_sortings_equal(self.SX2, SX_nwb)
         check_dumping(SX_nwb)
 
     def test_nixio_extractor(self):

--- a/spikeextractors/tests/test_extractors.py
+++ b/spikeextractors/tests/test_extractors.py
@@ -495,6 +495,7 @@ class TestExtractors(unittest.TestCase):
             skip_properties=['stability']
         )
         SX_nwb = se.NwbSortingExtractor(path1)
+        assert 'stability' not in SX_nwb.get_shared_unit_property_names()
         check_sortings_equal(self.SX, SX_nwb)
         check_dumping(SX_nwb)
 
@@ -506,6 +507,7 @@ class TestExtractors(unittest.TestCase):
             skip_features=['widths']
         )
         SX_nwb = se.NwbSortingExtractor(path1)
+        assert 'widths' not in SX_nwb.get_shared_unit_spike_feature_names()
         check_sortings_equal(self.SX2, SX_nwb)
         check_dumping(SX_nwb)
 


### PR DESCRIPTION
@bendichter @alejoe91 A couple small fixes for things that popped up in the CED pipeline.

1) Apparently, it's possible for the occasional recording extractor to have a sampling frequency that is an integer. Something in pynwb/hdmf wanted it to be a float, so this casts it.

2) For context, max_channel was a property we developed way back for the Yuta set to denote reference electrodes and link them in the spiking units table.

Apparently this same key is automatically set by certain types of returned sorting extractors from `spikesorters` in our pipelines. This isn't an issue in and of itself, _however_ the use of `quick_write` methods allow a possibility that we write a sorting extractor prior to writing any recording information, including an electrode table and hence we cannot complete the link of the electrode table reference.

The solution is simply to not establish the link if that is the case, and warn the user that is the case so that if they do want to include that link, they need to write recording information prior to the sorting extractor with the property set.