### PR TITLE
small fixes to NwbSortingExtractor.write_sorting

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -1232,8 +1232,6 @@ class NwbSortingExtractor(se.SortingExtractor):
                     flatten_vals = [item for sublist in values for item in sublist]
                     nspks_list = [sp for sp in nspikes.values()]
                     spikes_index = np.cumsum(nspks_list).astype('int64')
-                    print(nwbfile.units)
-                    print(unit_ids)
                     set_dynamic_table_property(
                         dynamic_table=nwbfile.units,
                         row_ids=unit_ids,


### PR DESCRIPTION
@alejoe91 Some undetected errors from earlier today.

Namely, the templates unit property which pops up automatically from some `spikesorters` is actually a tuple of values, which confuses `np.isnan` in that check.