### PR TITLE
Add nwb waveform writing

### DIFF
--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -311,6 +311,10 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         Optional. Path to the collection of .res and .clu text files. Will auto-detect format.
     keep_mua_units : bool
         Optional. Whether or not to return sorted spikes from multi-unit activity. Defaults to True.
+    spkfile_path : PathType
+        Optional. Path to a particular .spk binary file containing waveform snippets added to the extractor as features.
+    gain : float
+        Optional. If passing a spkfile_path, this value converts the data type of the waveforms to units of microvolts.
     """
 
     extractor_name = "NeuroscopeSortingExtractor"
@@ -325,7 +329,8 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         clufile_path: OptionalPathType = None,
         folder_path: OptionalPathType = None,
         keep_mua_units: bool = True,
-        spkfile_path: OptionalPathType = None
+        spkfile_path: OptionalPathType = None,
+        gain: Optional[float] = None
     ):
         assert HAVE_LXML, self.installation_mesg
         assert not (folder_path is None and resfile_path is None and clufile_path is None), \
@@ -416,6 +421,11 @@ class NeuroscopeSortingExtractor(SortingExtractor):
                 folder_path=None,
                 keep_mua_units=keep_mua_units
             )
+            
+        if spkfile_path is not None:
+            self._kwargs.update(spkfile_path=str(spkfile_path.absolute()))
+        else:
+            self._kwargs.update(spkfile_path=spkfile_path)
 
     def get_unit_ids(self):
         return list(self._unit_ids)

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -409,6 +409,23 @@ class NeuroscopeSortingExtractor(SortingExtractor):
                 for s_id in self._unit_ids:
                     self._spiketrains.append(res[(clu == s_id + 1).nonzero()])  # from 2,...,clu[0]-1
 
+        if spkfile_path is not None and Path(spkfile_path).is_file():
+            n_bits = int(xml_root.find('acquisitionSystem').find('nBits').text)
+            dtype = f"int{n_bits}"
+            n_samples = int(xml_root.find('neuroscope').find('spikes').find('nSamples').text)
+            wf = np.memmap(spkfile_path, dtype=dtype)
+            n_channels = int(wf.size / (n_spikes * n_samples))
+            wf = wf.reshape(n_spikes, n_samples, n_channels)
+
+            for unit_id in self.get_unit_ids():
+                if gain is not None:
+                    self.set_unit_property(unit_id=unit_id, property_name='gain', value=gain)
+                self.set_unit_spike_features(
+                    unit_id=unit_id,
+                    feature_name='waveforms',
+                    value=wf[clu == unit_id + 1 - int(keep_mua_units), :, :]
+                )
+
         if folder_path_passed:
             self._kwargs = dict(
                 resfile_path=None,
@@ -423,7 +440,6 @@ class NeuroscopeSortingExtractor(SortingExtractor):
                 folder_path=None,
                 keep_mua_units=keep_mua_units
             )
-            
         if spkfile_path is not None:
             self._kwargs.update(spkfile_path=str(spkfile_path.absolute()))
         else:
@@ -523,6 +539,11 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
     exclude_shanks : list
         Optional. List of indices to ignore. The set of all possible indices is chosen by default, extracted as the
         final integer of all the .res.%i and .clu.%i pairs.
+    write_waveforms : bool
+        Optional. If True, extracts waveform data from .spk.%i files in the path corresponding to
+        the .res.%i and .clue.%i files and sets these as unit spike features. Defaults to False.
+    gain : float
+        Optional. If passing a spkfile_path, this value converts the data type of the waveforms to units of microvolts.
     """
 
     extractor_name = "NeuroscopeMultiSortingExtractor"
@@ -535,7 +556,9 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
         self,
         folder_path: PathType,
         keep_mua_units: bool = True,
-        exclude_shanks: Optional[list] = None
+        exclude_shanks: Optional[list] = None,
+        write_waveforms: bool = False,
+        gain: Optional[float] = None
     ):
         assert HAVE_LXML, self.installation_mesg
 
@@ -576,16 +599,27 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
 
         all_shanks_list_se = []
         for shank_id in list(set(res_ids) - set(exclude_shanks)):
-            resfile_path = folder_path / f"{sorting_name}.res.{shank_id}"
-            clufile_path = folder_path / f"{sorting_name}.clu.{shank_id}"
-
-            all_shanks_list_se.append(
-                NeuroscopeSortingExtractor(
-                    resfile_path=resfile_path,
-                    clufile_path=clufile_path,
-                    keep_mua_units=keep_mua_units
-                )
+            nse_args = dict(
+                resfile_path=folder_path / f"{sorting_name}.res.{shank_id}",
+                clufile_path=folder_path / f"{sorting_name}.clu.{shank_id}",
+                keep_mua_units=keep_mua_units
             )
+
+            if write_waveforms:
+                spk_files = get_shank_files(folder_path=folder_path, suffix=".spk")
+                assert len(spk_files) > 0, "No .spk files found in the folder_path, but 'write_waveforms' is True!"
+                assert len(spk_files) == len(res_files), "Mismatched number of .spk and .res files!"
+
+                spk_ids = [int(x.suffix[1:]) for x in spk_files]
+                assert sorted(spk_ids) == sorted(res_ids), "Unmatched .spk.%i and .res.%i files detected!"
+
+                spkfile_names = [x.name[:x.name.find('.spk')] for x in spk_files]
+                assert np.all(s == r for (s, r) in zip(spkfile_names, resfile_names)), \
+                    "Some of the .spk.%i and .res.%i files do not share the same name!"
+
+                nse_args.update(spkfile_path=folder_path / f"{sorting_name}.spk.{shank_id}", gain=gain)
+
+            all_shanks_list_se.append(NeuroscopeSortingExtractor(**nse_args))
 
         MultiSortingExtractor.__init__(self, sortings=all_shanks_list_se)
 
@@ -593,13 +627,17 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
             self._kwargs = dict(
                 folder_path=str(folder_path.absolute()),
                 keep_mua_units=keep_mua_units,
-                exclude_shanks=exclude_shanks
+                exclude_shanks=exclude_shanks,
+                write_waveforms=write_waveforms,
+                gain=gain
             )
         else:
             self._kwargs = dict(
                 folder_path=str(folder_path.absolute()),
                 keep_mua_units=keep_mua_units,
-                exclude_shanks=None
+                exclude_shanks=None,
+                write_waveforms=write_waveforms,
+                gain=gain
             )
 
     @staticmethod

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -85,14 +85,10 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
         BinDatRecordingExtractor.__init__(self, file_path, sampling_frequency=sampling_frequency,
                                           dtype=dtype, numchan=numchan_from_file)
 
-<<<<<<< HEAD
-        self._kwargs = dict(file_path=str(Path(file_path).absolute()))
-=======
         if gain is not None:
             self.set_channel_gains(channel_ids=self.get_channel_ids(), gains=gain)
 
         self._kwargs = dict(file_path=str(Path(file_path).absolute()), gain=gain)
->>>>>>> master
 
     @staticmethod
     def write_recording(

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -69,7 +69,7 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
         assert len(xml_files) == 1, "More than one .xml file found in the folder_path."
         xml_filepath = xml_files[0]
 
-        xml_root = et.parse(str(xml_filepath).getroot())
+        xml_root = et.parse(str(xml_filepath)).getroot()
         n_bits = int(xml_root.find('acquisitionSystem').find('nBits').text)
         dtype = f"int{n_bits}"
         numchan_from_file = int(xml_root.find('acquisitionSystem').find('nChannels').text)
@@ -378,7 +378,7 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         assert len(xml_files) == 1, "More than one .xml file found in the folder!"
         xml_filepath = xml_files[0]
 
-        xml_root = et.parse(str(xml_filepath).getroot())
+        xml_root = et.parse(str(xml_filepath)).getroot()
         self._sampling_frequency = float(xml_root.find('acquisitionSystem').find('samplingRate').text)
 
         with open(resfile_path) as f:
@@ -576,7 +576,7 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
         assert len(xml_files) == 1, "More than one .xml file found in the folder!"
         xml_filepath = xml_files[0]
 
-        xml_root = et.parse(str(xml_filepath).getroot())
+        xml_root = et.parse(str(xml_filepath)).getroot()
         self._sampling_frequency = float(xml_root.find('acquisitionSystem').find('samplingRate').text)
 
         res_files = get_shank_files(folder_path=folder_path, suffix=".res")

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -431,14 +431,16 @@ class NeuroscopeSortingExtractor(SortingExtractor):
                 resfile_path=None,
                 clufile_path=None,
                 folder_path=str(folder_path.absolute()),
-                keep_mua_units=keep_mua_units
+                keep_mua_units=keep_mua_units,
+                gain=gain
             )
         else:
             self._kwargs = dict(
                 resfile_path=str(resfile_path.absolute()),
                 clufile_path=str(clufile_path.absolute()),
                 folder_path=None,
-                keep_mua_units=keep_mua_units
+                keep_mua_units=keep_mua_units,
+                gain=gain
             )
         if spkfile_path is not None:
             self._kwargs.update(spkfile_path=str(spkfile_path.absolute()))

--- a/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
+++ b/spikeextractors/extractors/neuroscopeextractors/neuroscopeextractors.py
@@ -84,7 +84,6 @@ class NeuroscopeRecordingExtractor(BinDatRecordingExtractor):
 
         BinDatRecordingExtractor.__init__(self, file_path, sampling_frequency=sampling_frequency,
                                           dtype=dtype, numchan=numchan_from_file)
-
         if gain is not None:
             self.set_channel_gains(channel_ids=self.get_channel_ids(), gains=gain)
 
@@ -319,10 +318,6 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         Optional. Path to the collection of .res and .clu text files. Will auto-detect format.
     keep_mua_units : bool
         Optional. Whether or not to return sorted spikes from multi-unit activity. Defaults to True.
-    spkfile_path : PathType
-        Optional. Path to a particular .spk binary file containing waveform snippets added to the extractor as features.
-    gain : float
-        Optional. If passing a spkfile_path, this value converts the data type of the waveforms to units of microvolts.
     """
 
     extractor_name = "NeuroscopeSortingExtractor"
@@ -336,9 +331,7 @@ class NeuroscopeSortingExtractor(SortingExtractor):
         resfile_path: OptionalPathType = None,
         clufile_path: OptionalPathType = None,
         folder_path: OptionalPathType = None,
-        keep_mua_units: bool = True,
-        spkfile_path: OptionalPathType = None,
-        gain: Optional[float] = None
+        keep_mua_units: bool = True
     ):
         assert HAVE_LXML, self.installation_mesg
         assert not (folder_path is None and resfile_path is None and clufile_path is None), \
@@ -417,43 +410,20 @@ class NeuroscopeSortingExtractor(SortingExtractor):
                 for s_id in self._unit_ids:
                     self._spiketrains.append(res[(clu == s_id + 1).nonzero()])  # from 2,...,clu[0]-1
 
-        if spkfile_path is not None and Path(spkfile_path).is_file():
-            n_bits = int(xml_root.find('acquisitionSystem').find('nBits').text)
-            dtype = f"int{n_bits}"
-            n_samples = int(xml_root.find('neuroscope').find('spikes').find('nSamples').text)
-            wf = np.memmap(spkfile_path, dtype=dtype)
-            n_channels = int(wf.size / (n_spikes * n_samples))
-            wf = wf.reshape(n_spikes, n_samples, n_channels)
-
-            for unit_id in self.get_unit_ids():
-                if gain is not None:
-                    self.set_unit_property(unit_id=unit_id, property_name='gain', value=gain)
-                self.set_unit_spike_features(
-                    unit_id=unit_id,
-                    feature_name='waveforms',
-                    value=wf[clu == unit_id + 1 - int(keep_mua_units), :, :]
-                )
-
         if folder_path_passed:
             self._kwargs = dict(
                 resfile_path=None,
                 clufile_path=None,
                 folder_path=str(folder_path.absolute()),
-                keep_mua_units=keep_mua_units,
-                gain=gain
+                keep_mua_units=keep_mua_units
             )
         else:
             self._kwargs = dict(
                 resfile_path=str(resfile_path.absolute()),
                 clufile_path=str(clufile_path.absolute()),
                 folder_path=None,
-                keep_mua_units=keep_mua_units,
-                gain=gain
+                keep_mua_units=keep_mua_units
             )
-        if spkfile_path is not None:
-            self._kwargs.update(spkfile_path=str(spkfile_path.absolute()))
-        else:
-            self._kwargs.update(spkfile_path=spkfile_path)
 
     def get_unit_ids(self):
         return list(self._unit_ids)
@@ -549,11 +519,6 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
     exclude_shanks : list
         Optional. List of indices to ignore. The set of all possible indices is chosen by default, extracted as the
         final integer of all the .res.%i and .clu.%i pairs.
-    write_waveforms : bool
-        Optional. If True, extracts waveform data from .spk.%i files in the path corresponding to
-        the .res.%i and .clue.%i files and sets these as unit spike features. Defaults to False.
-    gain : float
-        Optional. If passing a spkfile_path, this value converts the data type of the waveforms to units of microvolts.
     """
 
     extractor_name = "NeuroscopeMultiSortingExtractor"
@@ -566,9 +531,7 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
         self,
         folder_path: PathType,
         keep_mua_units: bool = True,
-        exclude_shanks: Optional[list] = None,
-        write_waveforms: bool = False,
-        gain: Optional[float] = None
+        exclude_shanks: Optional[list] = None
     ):
         assert HAVE_LXML, self.installation_mesg
 
@@ -609,27 +572,16 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
 
         all_shanks_list_se = []
         for shank_id in list(set(res_ids) - set(exclude_shanks)):
-            nse_args = dict(
-                resfile_path=folder_path / f"{sorting_name}.res.{shank_id}",
-                clufile_path=folder_path / f"{sorting_name}.clu.{shank_id}",
-                keep_mua_units=keep_mua_units
+            resfile_path = folder_path / f"{sorting_name}.res.{shank_id}"
+            clufile_path = folder_path / f"{sorting_name}.clu.{shank_id}"
+
+            all_shanks_list_se.append(
+                NeuroscopeSortingExtractor(
+                    resfile_path=resfile_path,
+                    clufile_path=clufile_path,
+                    keep_mua_units=keep_mua_units
+                )
             )
-
-            if write_waveforms:
-                spk_files = get_shank_files(folder_path=folder_path, suffix=".spk")
-                assert len(spk_files) > 0, "No .spk files found in the folder_path, but 'write_waveforms' is True!"
-                assert len(spk_files) == len(res_files), "Mismatched number of .spk and .res files!"
-
-                spk_ids = [int(x.suffix[1:]) for x in spk_files]
-                assert sorted(spk_ids) == sorted(res_ids), "Unmatched .spk.%i and .res.%i files detected!"
-
-                spkfile_names = [x.name[:x.name.find('.spk')] for x in spk_files]
-                assert np.all(s == r for (s, r) in zip(spkfile_names, resfile_names)), \
-                    "Some of the .spk.%i and .res.%i files do not share the same name!"
-
-                nse_args.update(spkfile_path=folder_path / f"{sorting_name}.spk.{shank_id}", gain=gain)
-
-            all_shanks_list_se.append(NeuroscopeSortingExtractor(**nse_args))
 
         MultiSortingExtractor.__init__(self, sortings=all_shanks_list_se)
 
@@ -637,17 +589,13 @@ class NeuroscopeMultiSortingExtractor(MultiSortingExtractor):
             self._kwargs = dict(
                 folder_path=str(folder_path.absolute()),
                 keep_mua_units=keep_mua_units,
-                exclude_shanks=exclude_shanks,
-                write_waveforms=write_waveforms,
-                gain=gain
+                exclude_shanks=exclude_shanks
             )
         else:
             self._kwargs = dict(
                 folder_path=str(folder_path.absolute()),
                 keep_mua_units=keep_mua_units,
-                exclude_shanks=None,
-                write_waveforms=write_waveforms,
-                gain=gain
+                exclude_shanks=None
             )
 
     @staticmethod

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -1148,7 +1148,7 @@ class NwbSortingExtractor(se.SortingExtractor):
                     print(f"Skipping property '{pr}' because it has variable size across units.")
                     skip_properties.update(pr)
 
-            write_properties = all_properties - skip_properties
+            write_properties = all_properties - set(skip_properties)
             for pr in write_properties:
                 if pr not in property_descriptions:
                     warnings.warn(
@@ -1214,7 +1214,7 @@ class NwbSortingExtractor(se.SortingExtractor):
                 nwbfile.add_unit(**unit_kwargs)
 
             # Check that multidimensional features have the same shape across units
-            write_features = all_features - skip_features
+            write_features = all_features - set(skip_features)
             feature_shapes = dict()
             for ft in write_features:
                 shapes = []

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -33,6 +33,11 @@ def check_nwb_install():
     assert HAVE_NWB, "To use the Nwb extractors, install pynwb: \n\n pip install pynwb\n\n"
 
 
+def check_waveform_features(sorting: se.SortingExtractor, unit_id: int):
+    assert 'waveforms' in sorting.get_unit_spike_feature_names(unit_id=unit_id), \
+        "Attempting to write waveforms, but there are none set as features in the SortingExtractor!"
+
+
 def set_dynamic_table_property(dynamic_table, row_ids, property_name, values, index=False,
                                default_value=np.nan, table=False, description='no description'):
     check_nwb_install()
@@ -98,17 +103,18 @@ def get_nspikes(units_table, unit_id):
 
 def most_relevant_ch(traces):
     """
-    Calculates the most relevant channel for an Unit.
+    Calculate the most relevant channel for a unit.
+
     Estimates the channel where the max-min difference of the average traces is greatest.
     traces : ndarray
-        ndarray of shape (nSpikes, nChannels, nSamples)
+        ndarray of shape (nSpikes, nSamples, nChannels)
     """
-    n_channels = traces.shape[1]
+    n_channels = traces.shape[2]
     avg = np.mean(traces, axis=0)
 
     max_min = np.zeros(n_channels)
     for ch in range(n_channels):
-        max_min[ch] = avg[ch, :].max() - avg[ch, :].min()
+        max_min[ch] = avg[:, ch].max() - avg[:, ch].min()
 
     relevant_ch = np.argmax(max_min)
     return relevant_ch
@@ -1071,12 +1077,19 @@ class NwbSortingExtractor(se.SortingExtractor):
             property_descriptions: Optional[dict] = None,
             skip_properties: Optional[List[str]] = None,
             skip_features: Optional[List[str]] = None,
-            timestamps: Optional[ArrayType] = None
-        ):
+            timestamps: Optional[ArrayType] = None,
+            write_waveforms: bool = False,
+            write_waveform_stats: bool = False
+    ):
         """Auxilliary function for write_sorting."""
+        if skip_properties is None:
+            skip_properties = set(['gain'])
+        if skip_features is None:
+            skip_features = set(['waveforms'])
+
         unit_ids = sorting.get_unit_ids()
-        fs = sorting.get_sampling_frequency()
-        if fs is None:
+        sf = sorting.get_sampling_frequency()
+        if sf is None:
             raise ValueError("Writing a SortingExtractor to an NWBFile requires a known sampling frequency!")
 
         all_properties = set()
@@ -1098,16 +1111,6 @@ class NwbSortingExtractor(se.SortingExtractor):
             property_descriptions = dict(default_descriptions)
         else:
             property_descriptions = dict(default_descriptions, **property_descriptions)
-        for pr in all_properties:
-            if pr not in property_descriptions:
-                warnings.warn(
-                    f"Description for property {pr} not found in property_descriptions. "
-                    "Setting description to 'no description'"
-                )
-        if skip_properties is None:
-            skip_properties = []
-        if skip_features is None:
-            skip_features = []
 
         if nwbfile.units is None:
             # Check that array properties have the same shape across units
@@ -1126,7 +1129,7 @@ class NwbSortingExtractor(se.SortingExtractor):
                                 shapes.append(np.array(prop_value).shape)
                         elif isinstance(prop_value, dict):
                             print(f"Skipping property '{pr}' because dictionaries are not supported.")
-                            skip_properties.append(pr)
+                            skip_properties.update(pr)
                             break
                     else:
                         shapes.append(np.nan)
@@ -1135,54 +1138,73 @@ class NwbSortingExtractor(se.SortingExtractor):
             for pr in property_shapes.keys():
                 if not np.all([elem == property_shapes[pr][0] for elem in property_shapes[pr]]):
                     print(f"Skipping property '{pr}' because it has variable size across units.")
-                    skip_properties.append(pr)
+                    skip_properties.update(pr)
 
-            write_properties = set(all_properties) - set(skip_properties)
+            write_properties = all_properties - skip_properties
             for pr in write_properties:
+                if pr not in property_descriptions:
+                    warnings.warn(
+                        f"Description for property {pr} not found in property_descriptions. "
+                        "Setting description to 'no description'"
+                    )
                 unit_col_args = dict(name=pr, description=property_descriptions.get(pr, "No description."))
                 if pr in ['max_channel', 'max_electrode'] and nwbfile.electrodes is not None:
                     unit_col_args.update(table=nwbfile.electrodes)
                 nwbfile.add_unit_column(**unit_col_args)
 
             for unit_id in unit_ids:
-                unit_kwargs = dict()
-                # spike trains withinin the SortingExtractor object are not scaled by sampling frequency
+                unit_kwargs = dict(id=unit_id)
+
+                # spike trains withinin the SortingExtractor object are in units of sampling frames
                 if timestamps is not None:
                     spike_train_frames = sorting.get_unit_spike_train(unit_id=unit_id)
-                    assert spike_train_frames[-1] < len(timestamps), "Number of 'timestamps' differs from number of " \
-                                                                     "'frames'!"
-                    spkt = np.array(timestamps)[spike_train_frames]
+                    assert spike_train_frames[-1] < len(timestamps), \
+                        "Number of 'timestamps' differs from number of 'frames'!"
+                    unit_kwargs.update(spike_times=np.array(timestamps)[spike_train_frames])
                 else:
-                    spkt = sorting.get_unit_spike_train(unit_id=unit_id) / fs
+                    unit_kwargs.update(spike_times=sorting.get_unit_spike_train(unit_id=unit_id) / sf)
+
                 for pr in write_properties:
                     if pr in sorting.get_unit_property_names(unit_id):
                         prop_value = sorting.get_unit_property(unit_id, pr)
                         unit_kwargs.update({pr: prop_value})
                     else:  # Case of missing data for this unit and this property
                         unit_kwargs.update({pr: np.nan})
-                nwbfile.add_unit(id=unit_id, spike_times=spkt, **unit_kwargs)
 
-            # TODO
-            # # Stores average and std of spike traces
-            # This will soon be updated to the current NWB standard
-            # if 'waveforms' in sorting.get_unit_spike_feature_names(unit_id=id):
-            #     wf = sorting.get_unit_spike_features(unit_id=id,
-            #                                          feature_name='waveforms')
-            #     relevant_ch = most_relevant_ch(wf)
-            #     # Spike traces on the most relevant channel
-            #     traces = wf[:, relevant_ch, :]
-            #     traces_avg = np.mean(traces, axis=0)
-            #     traces_std = np.std(traces, axis=0)
-            #     nwbfile.add_unit(
-            #         id=id,
-            #         spike_times=spkt,
-            #         waveform_mean=traces_avg,
-            #         waveform_sd=traces_std
-            #     )
+                if write_waveforms:
+                    check_waveform_features(sorting=sorting, unit_id=unit_id)
+                    wf = sorting.get_unit_spike_features(unit_id=unit_id, feature_name='waveforms')
+                    unit_kwargs.update(waveforms=wf)
+
+                if write_waveform_stats:
+                    check_waveform_features(sorting=sorting, unit_id=unit_id)
+                    wf = sorting.get_unit_spike_features(unit_id=unit_id, feature_name='waveforms')
+                    relevant_ch = most_relevant_ch(wf)
+                    traces = wf[:, :, relevant_ch]
+                    traces_avg = np.mean(traces, axis=0)
+                    traces_std = np.std(traces, axis=0)
+                    unit_kwargs.update(waveform_mean=traces_avg, waveform_sd=traces_std)
+
+                nwbfile.add_unit(**unit_kwargs)
+
+            if write_waveforms:
+                nwbfile.units.waveform_rate = sf  # Hz
+
+                # channels gains - for RecordingExtractor, these are values to cast traces to uV
+                # for nwb, the conversions (gains) cast the data to Volts
+                gain = np.unique(np.squeeze([
+                    sorting.get_unit_property(unit_id=unit_id, property_name='gain')
+                    if 'gain' in sorting.get_unit_property_names(unit_id=unit_id) else 1
+                    for unit_id in unit_ids
+                ]))
+                if len(gain) > 1:
+                    raise NotImplementedError("Writing waveforms with channel conversion factors is not supported!")
+                nwbfile.units.waveform_conversion = gain[0] * 1e-6
 
             # Check that multidimensional features have the same shape across units
+            write_features = all_features - skip_features
             feature_shapes = dict()
-            for ft in all_features:
+            for ft in write_features:
                 shapes = []
                 for unit_id in unit_ids:
                     if ft in sorting.get_unit_spike_feature_names(unit_id):
@@ -1195,11 +1217,11 @@ class NwbSortingExtractor(se.SortingExtractor):
                                 feature_shapes[ft] = shapes
                         elif isinstance(feat_value[0], dict):
                             print(f"Skipping feature '{ft}' because dictionaries are not supported.")
-                            skip_features.append(ft)
+                            write_features -= set(ft)
                             break
                     else:
                         print(f"Skipping feature '{ft}' because not share across all units.")
-                        skip_features.append(ft)
+                        write_features -= set(ft)
                         break
 
             nspikes = {k: get_nspikes(nwbfile.units, int(k)) for k in unit_ids}
@@ -1208,16 +1230,16 @@ class NwbSortingExtractor(se.SortingExtractor):
                 # skip first dimension (num_spikes) when comparing feature shape
                 if not np.all([elem[1:] == feature_shapes[ft][0][1:] for elem in feature_shapes[ft]]):
                     print(f"Skipping feature '{ft}' because it has variable size across units.")
-                    skip_features.append(ft)
+                    write_features -= set(ft)
 
-            for ft in set(all_features) - set(skip_features):
+            for ft in write_features:
                 values = []
                 if not ft.endswith('_idxs'):
                     for unit_id in sorting.get_unit_ids():
                         feat_vals = sorting.get_unit_spike_features(unit_id, ft)
 
                         if len(feat_vals) < nspikes[unit_id]:
-                            skip_features.append(ft)
+                            write_features -= set(ft)
                             print(f"Skipping feature '{ft}' because it is not defined for all spikes.")
                             break
                             # this means features are available for a subset of spikes
@@ -1251,11 +1273,12 @@ class NwbSortingExtractor(se.SortingExtractor):
             skip_properties: Optional[List[str]] = None,
             skip_features: Optional[List[str]] = None,
             timestamps: ArrayType = None,
+            write_waveforms: bool = False,
+            write_waveform_stats: bool = False,
             **nwbfile_kwargs
         ):
         """
         Primary method for writing a SortingExtractor object to an NWBFile.
-
         Parameters
         ----------
         sorting: SortingExtractor
@@ -1270,21 +1293,28 @@ class NwbSortingExtractor(se.SortingExtractor):
                 my_recording_extractor, my_nwbfile
             )
             will result in the appropriate changes to the my_nwbfile object.
-        property_descriptions: dict
+        property_descriptions: dict (optional)
             For each key in this dictionary which matches the name of a unit
-            property in sorting, adds the value as a description to that
+                property in sorting, adds the value as a description to that
             custom unit column.
-        skip_properties: list of str
+        skip_properties: list of str (optional)
             Each string in this list that matches a unit property will not be written to the NWBFile.
-        skip_features: list of str
+        skip_features: list of str (optional)
             Each string in this list that matches a spike feature will not be written to the NWBFile.
-        timestamps: array-like
+        timestamps: array-like (optional)
             If provided, the timestamps in seconds or the assiciated RecordingExtractor to be saved as the unit
-            timestamps. (default=None)
-        nwbfile_kwargs: dict
+                timestamps.
+            Defaults to None.
+        write_waveforms: bool (optional)
+            If True, writes the waveform spike features to the units table in the NWBFile.
+            Defaults to False.
+        write_waveform_stats: bool (optional)
+            If True, calculates the mean and standard deviation of the waveform spike feature for the
+                most relevant channel and writes to the units table in the NWBFile.
+            Defaults to False.
+        nwbfile_kwargs: dict (optional)
             Information for constructing the nwb file (optional).
-            Only used if no nwbfile exists at the save_path, and no nwbfile
-            was directly passed.
+            Only used if no nwbfile exists at the save_path, and no nwbfile was directly passed.
         """
         assert HAVE_NWB, NwbSortingExtractor.installation_mesg
         assert save_path is None or nwbfile is None, \
@@ -1315,7 +1345,9 @@ class NwbSortingExtractor(se.SortingExtractor):
                     property_descriptions=property_descriptions,
                     skip_properties=skip_properties,
                     skip_features=skip_features,
-                    timestamps=timestamps
+                    timestamps=timestamps,
+                    write_waveforms=write_waveforms,
+                    write_waveform_stats=write_waveform_stats
                 )
                 io.write(nwbfile)
         else:
@@ -1325,5 +1357,7 @@ class NwbSortingExtractor(se.SortingExtractor):
                     property_descriptions=property_descriptions,
                     skip_properties=skip_properties,
                     skip_features=skip_features,
-                    timestamps=timestamps
+                    timestamps=timestamps,
+                    write_waveforms=write_waveforms,
+                    write_waveform_stats=write_waveform_stats
             )

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -1206,7 +1206,7 @@ class NwbSortingExtractor(se.SortingExtractor):
                     check_waveform_features(sorting=sorting, unit_id=unit_id)
                     wf = sorting.get_unit_spike_features(unit_id=unit_id, feature_name='waveforms')
                     relevant_ch = most_relevant_ch(wf)
-                    traces = wf[:, :, relevant_ch]
+                    traces = wf[:, relevant_ch, :]
                     traces_avg = np.mean(traces, axis=0)
                     traces_std = np.std(traces, axis=0)
                     unit_kwargs.update(waveform_mean=traces_avg, waveform_sd=traces_std)


### PR DESCRIPTION
@alejoe91 Now that the changes are official in `pynwb`, we can allow unit spike features named 'waveforms' to be written to the units table as jagged columns.

EDIT: @bendichter Something I do notice in testing on actual data is there are occasional errors when adding waveforms whose outer dimensions are, in order `spikes x samples x channels`, with the number of channels varying over the channel groups. Switching this to `spikes x channels x samples` resolves this issue for the testing cases since the number of samples is always the same for each electrode group.

My question is, is there an established order for these 3 dimensions in the new NWB schema for waveforms on the units table? Is the above issue a problem we should look more into?