### PR TITLE
Fix issue 546

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -577,20 +577,11 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                             )
                         )
                     else:
-                        if group_id in range(len(nwbfile.electrode_groups)):
-                            group_name = list(nwbfile.electrode_groups.keys())[group_id]
-                            electrode_kwargs.update(
-                                dict(
-                                    group=nwbfile.electrode_groups[group_name],
-                                    group_name=group_name
-                                )
-                            )
-                        else:
-                            warnings.warn("No metadata was passed specifying the electrode group for "
-                                          f"electrode {channel_id}, and the internal recording channel group was "
-                                          f"assigned a value ({group_id}) outside the indices of the electrode "
-                                          "groups in the nwbfile! Electrode will not be added.")
-                            continue
+                        warnings.warn("No metadata was passed specifying the electrode group for "
+                                      f"electrode {channel_id}, and the internal recording channel group was "
+                                      f"assigned a value (str({group_id})) not present as electrode "
+                                      "groups in the NWBFile! Electrode will not be added.")
+                        continue
 
                 nwbfile.add_electrode(**electrode_kwargs)
         assert nwbfile.electrodes is not None, \

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -336,7 +336,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             name="Device",
             description="Ecephys probe."
         )
-        if metadata is None:
+        if metadata is None or 'Device' not in metadata['Ecephys']:
             metadata = dict(
                 Ecephys=dict(
                     Device=[defaults]
@@ -386,7 +386,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             location="unknown",
             device_name="Device"
         )
-        if metadata is None:
+        if metadata is None or 'ElectrodeGroup' not in metadata['Ecephys']:
             metadata = dict(
                 Ecephys=dict(
                     ElectrodeGroup=[]
@@ -466,6 +466,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
         if nwbfile is not None:
             assert isinstance(nwbfile, NWBFile), "'nwbfile' should be of type pynwb.NWBFile"
         if nwbfile.electrode_groups is None:
+            print("\n\n\nhere 1\n\n\n")
             se.NwbRecordingExtractor.add_electrode_groups(recording, nwbfile, metadata)
         # For older versions of pynwb, we need to manually add these columns
         if distutils.version.LooseVersion(pynwb.__version__) < '1.3.0':
@@ -485,7 +486,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             filtering="none",
             group_name="Electrode Group"
         )
-        if metadata is None:
+        if metadata is None or 'Electrodes' not in metadata['Ecephys']:
             metadata = dict(
                 Ecephys=dict(
                     Electrodes=[]
@@ -649,7 +650,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             name="LFP",
             description="Local field potential signal."
         )
-        if metadata is None:
+        if metadata is None or not any([x in metadata['Ecephys'] for x in ['ElectricalSeries', 'LFPElectricalSeries']]):
             metadata = dict(Ecephys=dict())
             if not write_as_lfp:
                 metadata['Ecephys'].update(


### PR DESCRIPTION
Fix issue 546

@alejoe91 Per internal discussion, checking if the string equivalent of the channel's group id is in the `nwbfile.electrode_groups` before attempting the last-ditch index search.

Also improved metadata defaulting to allow a partial metadata dictionary to be passed. Also added assertion with more informative message in the case where no electrode table is written by consequence of the `continue` warning in the iteration.

@khl02007 This ought to fix your issue, if you can give this branch a try.