### PR TITLE
property fixes multichannel

### DIFF
--- a/spikeextractors/multirecordingchannelextractor.py
+++ b/spikeextractors/multirecordingchannelextractor.py
@@ -57,8 +57,9 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
             recording = self._recordings[self._channel_map[channel_id]['recording']]
             channel_id_recording = self._channel_map[channel_id]['channel_id']
             for property_name in recording.get_channel_property_names(channel_id_recording):
-                value = recording.get_channel_property(channel_id_recording, property_name)
-                self.set_channel_property(channel_id=channel_id, property_name=property_name, value=value)
+                if property_name not in ("group", "location"):
+                    value = recording.get_channel_property(channel_id_recording, property_name)
+                    self.set_channel_property(channel_id=channel_id, property_name=property_name, value=value)
 
         self._kwargs = {'recordings': [rec.make_serialized_dict() for rec in recordings], 'groups': groups}
 

--- a/spikeextractors/multirecordingchannelextractor.py
+++ b/spikeextractors/multirecordingchannelextractor.py
@@ -41,7 +41,7 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
                     channel_ids = recording.get_channel_ids()
                     recording_groups = [group] * len(channel_ids)
                     group_values += recording_groups
-                    recording.set_channel_groups(groups=recording_groups)
+                   
                 self.set_channel_groups(groups=group_values)
             else:
                 raise ValueError("recordings and groups must have same length")

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -539,23 +539,24 @@ class RecordingExtractor(ABC, BaseExtractor):
             The list (or single value) of channel_ids for which the properties will be copied
         '''
         if channel_ids is None:
-            channel_ids = self.get_channel_ids()
-        elif isinstance(channel_ids, (int, np.integer)):
-            channel_ids = [channel_ids]
+            self._key_properties = deepcopy(recording._key_properties)
+            self._properties = deepcopy(recording._properties)
+        else:
+            if isinstance(channel_ids, (int, np.integer)):
+                channel_ids = [channel_ids]
+            # copy key properties
+            groups = recording.get_channel_groups(channel_ids=channel_ids)
+            locations = recording.get_channel_locations(channel_ids=channel_ids)
+            self.set_channel_groups(groups)
+            self.set_channel_locations(locations)
 
-        # copy key properties
-        groups = recording.get_channel_groups(channel_ids=channel_ids)
-        locations = recording.get_channel_locations(channel_ids=channel_ids)
-        self.set_channel_groups(groups)
-        self.set_channel_locations(locations)
-
-        # copy normal properties
-        for channel_id in channel_ids:
-            curr_property_names = recording.get_channel_property_names(channel_id=channel_id)
-            for curr_property_name in curr_property_names:
-                if curr_property_name not in self._key_properties.keys():  # key property
-                    value = recording.get_channel_property(channel_id=channel_id, property_name=curr_property_name)
-                    self.set_channel_property(channel_id=channel_id, property_name=curr_property_name, value=value)
+            # copy normal properties
+            for channel_id in channel_ids:
+                curr_property_names = recording.get_channel_property_names(channel_id=channel_id)
+                for curr_property_name in curr_property_names:
+                    if curr_property_name not in self._key_properties.keys():  # key property
+                        value = recording.get_channel_property(channel_id=channel_id, property_name=curr_property_name)
+                        self.set_channel_property(channel_id=channel_id, property_name=curr_property_name, value=value)
 
     def clear_channel_property(self, channel_id, property_name):
         '''This function clears the channel property for the given property.

--- a/spikeextractors/recordingextractor.py
+++ b/spikeextractors/recordingextractor.py
@@ -539,25 +539,23 @@ class RecordingExtractor(ABC, BaseExtractor):
             The list (or single value) of channel_ids for which the properties will be copied
         '''
         if channel_ids is None:
-            self._key_properties = deepcopy(recording._key_properties)
-            self._properties = deepcopy(recording._properties)
-        else:
-            if isinstance(channel_ids, (int, np.integer)):
-                channel_ids = [channel_ids]
+            channel_ids = self.get_channel_ids()
+        elif isinstance(channel_ids, (int, np.integer)):
+            channel_ids = [channel_ids]
 
-            # copy key properties
-            groups = recording.get_channel_groups(channel_ids=channel_ids)
-            locations = recording.get_channel_locations(channel_ids=channel_ids)
-            self.set_channel_groups(groups)
-            self.set_channel_locations(locations)
+        # copy key properties
+        groups = recording.get_channel_groups(channel_ids=channel_ids)
+        locations = recording.get_channel_locations(channel_ids=channel_ids)
+        self.set_channel_groups(groups)
+        self.set_channel_locations(locations)
 
-            # copy normal properties
-            for channel_id in channel_ids:
-                curr_property_names = recording.get_channel_property_names(channel_id=channel_id)
-                for curr_property_name in curr_property_names:
-                    if curr_property_name not in self._key_properties.keys():  # key property
-                        value = recording.get_channel_property(channel_id=channel_id, property_name=curr_property_name)
-                        self.set_channel_property(channel_id=channel_id, property_name=curr_property_name, value=value)
+        # copy normal properties
+        for channel_id in channel_ids:
+            curr_property_names = recording.get_channel_property_names(channel_id=channel_id)
+            for curr_property_name in curr_property_names:
+                if curr_property_name not in self._key_properties.keys():  # key property
+                    value = recording.get_channel_property(channel_id=channel_id, property_name=curr_property_name)
+                    self.set_channel_property(channel_id=channel_id, property_name=curr_property_name, value=value)
 
     def clear_channel_property(self, channel_id, property_name):
         '''This function clears the channel property for the given property.

--- a/spikeextractors/tests/test_extractors.py
+++ b/spikeextractors/tests/test_extractors.py
@@ -381,7 +381,6 @@ class TestExtractors(unittest.TestCase):
             recordings=[self.RX, self.RX2, self.RX3],
             groups=[1, 2, 3]
         )
-        print(RX_multi.get_channel_groups())
         RX_sub = se.SubRecordingExtractor(RX_multi, channel_ids=[4, 5, 6, 7], renamed_channel_ids=[0, 1, 2, 3])
         check_recordings_equal(self.RX2, RX_sub)
         check_recordings_equal(self.RX, RX_multi.recordings[0])
@@ -389,6 +388,20 @@ class TestExtractors(unittest.TestCase):
         check_recordings_equal(self.RX3, RX_multi.recordings[2])
         self.assertEqual([2, 2, 2, 2], list(RX_sub.get_channel_groups()))
         self.assertEqual(12, len(RX_multi.get_channel_ids()))
+
+        rx1 = self.RX
+        rx2 = self.RX2
+        rx3 = self.RX3
+        rx2.set_channel_property(0, "foo", 100)
+        rx3.set_channel_locations([11, 11], channel_ids=0)
+        RX_multi_c = se.MultiRecordingChannelExtractor(
+            recordings=[rx1, rx2, rx3],
+            groups=[0, 0, 1]
+        )
+        self.assertTrue(np.array_equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], RX_multi_c.get_channel_ids()))
+        self.assertTrue(np.array_equal([0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1], RX_multi_c.get_channel_groups()))
+        self.assertEqual(rx2.get_channel_property(0, "foo"), RX_multi_c.get_channel_property(4, "foo"))
+        self.assertTrue(np.array_equal(rx3.get_channel_locations([0])[0], RX_multi_c.get_channel_locations([8])[0]))
 
     def test_ttl_frames_in_sub_multi(self):
         # sub recording


### PR DESCRIPTION
Fixes #553 

Quick explanation: `MultiRecordingChannelExtractor` used to fetch properties from each internal extractor, as a result, the `._properties` dictionary was empty. As `copy_channel_properties` was sometimes deepcopying the `._properties` dictionary, this would cause properties to not be inherited by the `CacheRecordingExtractor` when wrapping a `MultiRecordingChannelExtractor`.

Fix: `MultiRecordingChannelExtractor` now fills the `._properties` dictionary with all of the internal extractor properties and then does not reference the internal extractor properties anymore. This means that **changes to the multiextractor properties will no longer change the internal extractor properties**. Is this behaviour ok @alejoe91 ? I think it is much more straightforward and less prone to error this way.

I added tests as well.