### PR TITLE
Debugging for petersen

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -1244,7 +1244,7 @@ class NwbSortingExtractor(se.SortingExtractor):
                     spikes_index = np.cumsum(nspks_list).astype('int64')
                     set_dynamic_table_property(
                         dynamic_table=nwbfile.units,
-                        row_ids=unit_ids,
+                        row_ids=[int(k) for k in unit_ids],
                         property_name=ft,
                         values=flatten_vals,
                         index=spikes_index,

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -1081,7 +1081,7 @@ class NwbSortingExtractor(se.SortingExtractor):
             skip_properties: Optional[List[str]] = None,
             skip_features: Optional[List[str]] = None,
             timestamps: Optional[ArrayType] = None
-        ):
+    ):
         """Auxilliary function for write_sorting."""
         unit_ids = sorting.get_unit_ids()
         fs = sorting.get_sampling_frequency()
@@ -1101,7 +1101,8 @@ class NwbSortingExtractor(se.SortingExtractor):
             max_channel="The recording channel id with the largest amplitude.",
             halfwidth="The full-width half maximum of the negative peak computed on the maximum channel.",
             peak_to_valley="The duration between the negative and the positive peaks computed on the maximum channel.",
-            snr="The signal-to-noise ratio of the unit."
+            snr="The signal-to-noise ratio of the unit.",
+            quality="Quality of the unit as defined by phy (good, mua, noise)."
         )
         if property_descriptions is None:
             property_descriptions = dict(default_descriptions)

--- a/spikeextractors/extractors/phyextractors/phyextractors.py
+++ b/spikeextractors/extractors/phyextractors/phyextractors.py
@@ -1,9 +1,13 @@
-from spikeextractors import SortingExtractor, RecordingExtractor
-from spikeextractors.extractors.bindatrecordingextractor import BinDatRecordingExtractor
-from spikeextractors.extraction_tools import read_python, write_python, check_valid_unit_id
 import numpy as np
 from pathlib import Path
 import csv
+from typing import Union, Optional
+
+from spikeextractors import SortingExtractor, RecordingExtractor
+from spikeextractors.extractors.bindatrecordingextractor import BinDatRecordingExtractor
+from spikeextractors.extraction_tools import read_python, check_valid_unit_id
+
+PathType = Union[str, Path]
 
 
 class PhyRecordingExtractor(BinDatRecordingExtractor):
@@ -14,7 +18,7 @@ class PhyRecordingExtractor(BinDatRecordingExtractor):
     mode = 'folder'
     installation_mesg = ""  # error message when not installed
 
-    def __init__(self, folder_path):
+    def __init__(self, folder_path: PathType):
         RecordingExtractor.__init__(self)
         phy_folder = Path(folder_path)
 
@@ -54,7 +58,13 @@ class PhySortingExtractor(SortingExtractor):
     mode = 'folder'
     installation_mesg = ""  # error message when not installed
 
-    def __init__(self, folder_path, exclude_cluster_groups=None, load_waveforms=False, verbose=False):
+    def __init__(
+            self,
+            folder_path: PathType,
+            exclude_cluster_groups: Optional[list] = None,
+            load_waveforms: bool = False,
+            verbose: bool = False
+    ):
         SortingExtractor.__init__(self)
         phy_folder = Path(folder_path)
 


### PR DESCRIPTION
@alejoe91 Various debugs for converting the PetersenP dataset from the Buzsaki lab.

1) Though I've run into the situation before, where there are multiple .xml files in a single folder, this is the first time those extra ones haven't been accidental or non-informative. There are actually multiple valid and useful .xml files, so I'm just adding a `xml_file_path` argument to Neuroscope as a manual bypass of the auto-detection.

2) The newer versions of the Neuroscope format call the `.eeg` LFP files `.lfp`. Same exact internal format though.

3) Added annotation typing to Phy extractors for their new data interfaces over on nwb-conversion-tools.