### PR TITLE
Fix SpikeGLX locations and channel names

### DIFF
--- a/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
@@ -39,11 +39,11 @@ class SpikeGLXRecordingExtractor(RecordingExtractor):
                'imec.ap' in self._npxfile.name or 'imec.lf' in self._npxfile.name or 'nidq' in self._npxfile.name, \
                "'file_path' can be an imec.ap, imec.lf, imec0.ap, imec0.lf, or nidq file"
         assert 'bin' in self._npxfile.name, "The 'npx_file should be either the 'ap', 'lf', or 'nidq' bin file."
-        if 'imec0.ap' in str(self._npxfile):
+        if 'ap.bin' in str(self._npxfile):
             lfp = False
             ap = True
             self.is_filtered = True
-        elif 'imec0.lf' in str(self._npxfile):
+        elif 'lf.bin' in str(self._npxfile):
             lfp = True
             ap = False
         else:


### PR DESCRIPTION
Fixes https://github.com/SpikeInterface/spikeextractors/issues/564 and https://github.com/SpikeInterface/spikeextractors/issues/561

https://github.com/SpikeInterface/spikeextractors/issues/564
The problem was that the conditions to define AP, LF, or NIDQ recordings were based on the assumptions that `imec0` is in the file name. However, some file names can also only have `imec`

https://github.com/SpikeInterface/spikeextractors/issues/561
The staggered configuration needed to be added 'manually'. Basically every other row will be shifted by x_pitch // 2. The x_pitch has been updated to 32 (16 * 2), as this is the actual distance of the electrodes on the same row.