### PR TITLE
Updates to BinDat and Phy extractors

### DIFF
--- a/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
+++ b/spikeextractors/extractors/bindatrecordingextractor/bindatrecordingextractor.py
@@ -3,10 +3,42 @@ from spikeextractors.extraction_tools import read_binary, write_to_binary_dat_fo
 import shutil
 import numpy as np
 from pathlib import Path
-import os
+from typing import Union, Optional
 
+PathType = Union[str, Path]
+DtypeType = Union[str, np.dtype]
+ArrayType = Union[list, np.ndarray]
 
 class BinDatRecordingExtractor(RecordingExtractor):
+    """
+    RecordingExtractor for a binary format
+
+    Parameters
+    ----------
+    file_path: str or Path
+        Path to the binary file
+    sampling_frequency: float
+        The sampling frequncy
+    numchan: int
+        Number of channels
+    dtype: str or dtype
+        The dtype of the binary file
+    time_axis: int
+        The axis of the time dimension (default 0: F order)
+    recording_channels: list (optional)
+        A list of channel ids
+    offset: float (optional)
+        The offset to apply to the traces
+    geom: array-like (optional)
+        A list or array with channel locations
+    gain: float (optional)
+        The gain to apply to the traces
+    gain_first: bool
+        If True and gain and offset are provided, traces are scaled as: original_traces * gain - offset
+        If False and gain and offset are provided, traces are scaled as: (original_traces - offset) * gain
+    is_filtered: bool
+        If True, the recording is assumed to be filtered
+    """
     extractor_name = 'BinDatRecordingExtractor'
     has_default_locations = False
     installed = True  # check at class level if installed or not
@@ -14,8 +46,10 @@ class BinDatRecordingExtractor(RecordingExtractor):
     mode = 'file'
     installation_mesg = ""  # error message when not installed
 
-    def __init__(self, file_path, sampling_frequency, numchan, dtype, recording_channels=None,
-                 time_axis=0, geom=None, offset=0, gain=None, is_filtered=None):
+    def __init__(self, file_path: PathType, sampling_frequency: float, numchan: int, dtype: DtypeType,
+                 time_axis: int = 0, recording_channels: Optional[list] = None,  geom: Optional[ArrayType] = None,
+                 offset: Optional[float] = 0, gain: Optional[float] = None, gain_first: bool = True,
+                 is_filtered: Optional[bool] = None):
         RecordingExtractor.__init__(self)
         self._datfile = Path(file_path)
         self._time_axis = time_axis
@@ -25,6 +59,7 @@ class BinDatRecordingExtractor(RecordingExtractor):
         self._numchan = numchan
         self._geom = geom
         self._offset = offset
+        self._gain_first = gain_first
         self._timeseries = read_binary(self._datfile, numchan, dtype, time_axis, offset)
 
         # keep track of filter status when dumping
@@ -34,11 +69,18 @@ class BinDatRecordingExtractor(RecordingExtractor):
             self.is_filtered = False
 
         if recording_channels is not None:
-            assert len(recording_channels) == self._timeseries.shape[0], \
+            assert len(recording_channels) <= self._timeseries.shape[0], \
                'Provided recording channels have the wrong length'
             self._channels = recording_channels
         else:
             self._channels = list(range(self._timeseries.shape[0]))
+
+        if len(self._channels) == self._timeseries.shape[0]:
+            self._complete_channels = True
+        else:
+            assert max(self._channels) < self._timeseries.shape[0], "Channel ids exceed the number of " \
+                                                                    "available channels"
+            self._complete_channels = False
 
         if geom is not None:
             self.set_channel_locations(self._geom)
@@ -64,21 +106,36 @@ class BinDatRecordingExtractor(RecordingExtractor):
 
     @check_get_traces_args
     def get_traces(self, channel_ids=None, start_frame=None, end_frame=None):
-        if np.all(channel_ids == self.get_channel_ids()):
-            recordings = self._timeseries[:, start_frame:end_frame]
-        else:
-            channel_idxs = np.array([self.get_channel_ids().index(ch) for ch in channel_ids])
-            if np.all(np.diff(channel_idxs) == 1):
-                recordings = self._timeseries[channel_idxs[0]:channel_idxs[0]+len(channel_idxs), start_frame:end_frame]
+        if self._complete_channels:
+            if np.all(channel_ids == self.get_channel_ids()):
+                recordings = self._timeseries[:, start_frame:end_frame]
             else:
-                # This block of the execution will return the data as an array, not a memmap
-                recordings = self._timeseries[channel_idxs, start_frame:end_frame]
-        if self._dtype.startswith('uint'):
-            exp_idx = self._dtype.find('int') + 3
-            exp = int(self._dtype[exp_idx:])
-            recordings = recordings.astype('float32') - 2**(exp - 1)
+                channel_idxs = np.array([self.get_channel_ids().index(ch) for ch in channel_ids])
+                if np.all(np.diff(channel_idxs) == 1):
+                    recordings = self._timeseries[channel_idxs[0]:channel_idxs[0]+len(channel_idxs),
+                                 start_frame:end_frame]
+                else:
+                    # This block of the execution will return the data as an array, not a memmap
+                    recordings = self._timeseries[channel_idxs, start_frame:end_frame]
+        else:
+            # in this case channel ids are actually indexes
+            recordings = self._timeseries[channel_ids, start_frame:end_frame]
+
         if self._gain is not None:
-            recordings = recordings * self._gain
+            # unint needs to be converted to float in this case!
+            if self._dtype.startswith('uint'):
+                exp_idx = self._dtype.find('int') + 3
+                exp = int(self._dtype[exp_idx:])
+                recordings = recordings.astype('float32') - 2 ** (exp - 1)
+            if self._offset is None:
+                offset = 0
+            else:
+                offset = self._offset
+            if self._gain_first:
+                recordings = recordings * self._gain - offset
+            else:
+                recordings = (recordings - offset) * self._gain
+
         return recordings
 
     def write_to_binary_dat_format(self, save_path, time_axis=0, dtype=None, chunk_size=None, chunk_mb=500,

--- a/spikeextractors/extractors/phyextractors/phyextractors.py
+++ b/spikeextractors/extractors/phyextractors/phyextractors.py
@@ -11,6 +11,14 @@ PathType = Union[str, Path]
 
 
 class PhyRecordingExtractor(BinDatRecordingExtractor):
+    """
+    RecordingExtractor for a Phy output folder
+
+    Parameters
+    ----------
+    folder_path: str or Path
+        Path to the output Phy folder (containing the params.py)
+    """
     extractor_name = 'PhyRecording'
     has_default_locations = True
     installed = True  # check at class level if installed or not
@@ -27,10 +35,10 @@ class PhyRecordingExtractor(BinDatRecordingExtractor):
 
         if (phy_folder / 'channel_map_si.npy').is_file():
             channel_map = list(np.squeeze(np.load(phy_folder / 'channel_map_si.npy')))
-            assert len(channel_map) == self.params['n_channels_dat']
+            assert max(channel_map) < self.params['n_channels_dat'], "Channel map inconsistent with dat file."
         elif (phy_folder / 'channel_map.npy').is_file():
             channel_map = list(np.squeeze(np.load(phy_folder / 'channel_map.npy')))
-            assert len(channel_map) == self.params['n_channels_dat']
+            assert max(channel_map) < self.params['n_channels_dat'], "Channel map inconsistent with dat file."
         else:
             channel_map = list(range(self.params['n_channels_dat']))
 
@@ -52,19 +60,23 @@ class PhyRecordingExtractor(BinDatRecordingExtractor):
 
 
 class PhySortingExtractor(SortingExtractor):
+    """
+    SortingExtractor for a Phy output folder
+
+    Parameters
+    ----------
+    folder_path: str or Path
+        Path to the output Phy folder (containing the params.py)
+    exclude_cluster_groups: list (optional)
+        List of cluster groups to exclude (e.g. ["noise", "mua"]
+    """
     extractor_name = 'PhySortingExtractor'
     installed = True  # check at class level if installed or not
     is_writable = False
     mode = 'folder'
     installation_mesg = ""  # error message when not installed
 
-    def __init__(
-            self,
-            folder_path: PathType,
-            exclude_cluster_groups: Optional[list] = None,
-            load_waveforms: bool = False,
-            verbose: bool = False
-    ):
+    def __init__(self, folder_path: PathType, exclude_cluster_groups: Optional[list] = None):
         SortingExtractor.__init__(self)
         phy_folder = Path(folder_path)
 
@@ -159,49 +171,8 @@ class PhySortingExtractor(SortingExtractor):
             if pc_features is not None:
                 self.set_unit_spike_features(clust, 'pc_features', pc_features[idx])
 
-        if load_waveforms:
-            datfile = [x for x in phy_folder.iterdir() if x.suffix == '.dat' or x.suffix == '.bin']
-
-            recording = BinDatRecordingExtractor(datfile[0], sampling_frequency=float(self.params['sample_rate']),
-                                                 dtype=self.params['dtype'], numchan=self.params['n_channels_dat'])
-            # if channel groups are present, compute waveforms by group
-            if (phy_folder / 'channel_groups.npy').is_file():
-                channel_groups = np.load(phy_folder / 'channel_groups.npy')
-                assert len(channel_groups) == recording.get_num_channels()
-                recording.set_channel_groups(channel_groups)
-                for u_i, u in enumerate(self.get_unit_ids()):
-                    if verbose:
-                        print('Computing waveform by group for unit', u)
-                    frames_before = int(0.5 / 1000. * recording.get_sampling_frequency())
-                    frames_after = int(2 / 1000. * recording.get_sampling_frequency())
-                    spiketrain = self.get_unit_spike_train(u)
-                    if 'group' in self.get_unit_property_names(u):
-                        group_idx = np.where(channel_groups == int(self.get_unit_property(u, 'group')))[0]
-                        wf = recording.get_snippets(reference_frames=spiketrain,
-                                                    snippet_len=[frames_before, frames_after],
-                                                    channel_ids=group_idx)
-                    else:
-                        wf = recording.get_snippets(reference_frames=spiketrain,
-                                                    snippet_len=[frames_before, frames_after])
-                        max_chan = np.unravel_index(np.argmin(np.mean(wf, axis=0)), np.mean(wf, axis=0).shape)[0]
-                        group = recording.get_channel_groups(int(max_chan))
-                        self.set_unit_property(u, 'group', group)
-                        group_idx = np.where(channel_groups == group)[0]
-                        wf = wf[:, group_idx]
-                    self.set_unit_spike_features(u, 'waveforms', wf)
-            else:
-                for u_i, u in enumerate(self.get_unit_ids()):
-                    if verbose:
-                        print('Computing full waveform for unit', u)
-                    frames_before = 0.5 * recording.get_sampling_frequency()
-                    frames_after = 2 * recording.get_sampling_frequency()
-                    spiketrain = self.get_unit_spike_train(u)
-                    wf = recording.get_snippets(reference_frames=spiketrain,
-                                                snippet_len=[int(frames_before), int(frames_after)])
-                    self.set_unit_spike_features(u, 'waveforms', wf)
         self._kwargs = {'folder_path': str(Path(folder_path).absolute()),
-                        'exclude_cluster_groups': exclude_cluster_groups,
-                        'load_waveforms': load_waveforms, 'verbose': verbose}
+                        'exclude_cluster_groups': exclude_cluster_groups}
 
     def get_unit_ids(self):
         return list(self._unit_ids)


### PR DESCRIPTION
### `BinDatRecordingExtractor`

- Enable to have `channel_ids` as a subset of the number of channels in the binary file (fixes https://github.com/SpikeInterface/spikeextractors/issues/387)
- Added `gain_first` argument to control how `gain` and `offset` should be applied
- Added docstring

### `PhySortingExtractor`

- Removed `load_waveforms` and `verbose` arguments. Waveforms must be computed with `spiketoolkit` or uploaded externally
- dded docstrings
