### PR TITLE
Modified assertion check to accept all imecX.lf or imecX.ap file as input

### DIFF
--- a/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
@@ -3,7 +3,7 @@ from .readSGLX import readMeta, SampRate, makeMemMapRaw, GainCorrectIM, GainCorr
 import numpy as np
 from pathlib import Path
 from spikeextractors.extraction_tools import check_get_traces_args, check_get_ttl_args
-
+import re
 
 class SpikeGLXRecordingExtractor(RecordingExtractor):
     """
@@ -34,11 +34,12 @@ class SpikeGLXRecordingExtractor(RecordingExtractor):
 
         assert dtype in ['int16', 'float'], "'dtype' can be either 'int16' or 'float'"
         self._dtype = dtype
-        # Gets file type: 'imec0.ap', 'imec0.lf' or 'nidq'
-        assert 'imec0.ap' in self._npxfile.name or 'imec0.lf' in self._npxfile.name or \
-               'imec.ap' in self._npxfile.name or 'imec.lf' in self._npxfile.name or 'nidq' in self._npxfile.name, \
-               "'file_path' can be an imec.ap, imec.lf, imec0.ap, imec0.lf, or nidq file"
+        
         assert 'bin' in self._npxfile.name, "The 'npx_file should be either the 'ap', 'lf', or 'nidq' bin file."
+        # Gets file type: 'imec0.ap', 'imec0.lf' or 'nidq'
+        assert re.search(r'imec[0-9]*.(ap|lf){1}.bin$', self._npxfile.name) or  'nidq' in self._npxfile.name, \
+               "'file_path' can be an imec.ap, imec.lf, imec0.ap, imec0.lf, or nidq file"
+           
         if 'ap.bin' in str(self._npxfile):
             rec_type = "ap"
             self.is_filtered = True


### PR DESCRIPTION
Accept  now
- imec.ap.bin
- imec.lf.bin
- imecX.lf.bin      with X the recording number
- imecX.ap.bin

close #583 

@gmaggi  Do you think you could checkout on this branch on the cluster please ? I want to verify that the pipeline is not breaking later with the imec1 file and also Hanna needs to send her jobs as soon as possible. 

@alejoe91 , @samuelgarcia    should i add some tests to keep track of the allowed filenames ?
