### PR TITLE
fix issue 587

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -6,12 +6,12 @@ import numpy as np
 import distutils.version
 from typing import Union, List, Optional
 import warnings
-import pandas as pd
 
 import spikeextractors as se
 from spikeextractors.extraction_tools import check_get_traces_args, check_get_unit_spike_train
 
 try:
+    import pandas as pd
     import pynwb
     from pynwb import NWBHDF5IO
     from pynwb import NWBFile

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -6,13 +6,13 @@ import numpy as np
 import distutils.version
 from typing import Union, List, Optional
 import warnings
+import pandas as pd
 
 import spikeextractors as se
 from spikeextractors.extraction_tools import check_get_traces_args, check_get_unit_spike_train
 
 try:
     import pynwb
-    import pandas as pd
     from pynwb import NWBHDF5IO
     from pynwb import NWBFile
     from pynwb.ecephys import ElectricalSeries, LFP
@@ -511,7 +511,6 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                 nwbfile.add_electrode_column('rel_y', 'y position of electrode in electrode group')
 
         defaults = dict(
-            id=np.nan,
             x=np.nan,
             y=np.nan,
             z=np.nan,


### PR DESCRIPTION
fix #587 

Part (a) of that issue dealt with auto-population of the electrical series name, which is now properly fixed.
Part (b) is the odd error that occurs, for example, if the electrode ids in the nwbfile.electrodes table were not added in increasing order - the original direct indexing of the electrical series region (which are indexes of ids in the electrodes table) through the table caused an error through h5py and is now fixed by list compression passing through a single index at a time.
Part (c) is unfortunately the fact that the electrode ids weren't unique to begin with, making it an invalid NWBFile. Reaching out to try to fix in the independent software, but [a PR fix has been proposed on PyNWB](https://github.com/NeurodataWithoutBorders/pynwb/pull/1344), at least.
