### PR TITLE
Neoextractors channel ids patch

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 datalad
 parameterized
 numpy
+neo==0.9.0
 tqdm
 lxml
 h5py
@@ -13,6 +14,5 @@ exdir==0.4.1
 pyintan
 tridesclous
 hdbscan
-neo
 pyopenephys
 xmltodict

--- a/spikeextractors/extractors/neoextractors/neobaseextractor.py
+++ b/spikeextractors/extractors/neoextractors/neobaseextractor.py
@@ -119,10 +119,16 @@ class NeoBaseRecordingExtractor(RecordingExtractor, _NeoBaseExtractor):
         # there is no garranty that ids/names are unique on some formats
         channel_idxs = [self.get_channel_ids().index(ch) for ch in channel_ids]
         neo_chan_ids = self._neo_chan_ids[channel_idxs]
-        raw_traces = self.neo_reader.get_analogsignal_chunk(block_index=self.block_index, seg_index=self.seg_index,
-                                                            i_start=start_frame, i_stop=end_frame,
-                                                            channel_indexes=None, channel_names=None,
-                                                            stream_index=0, channel_ids=neo_chan_ids)
+        if self.after_v10:
+            raw_traces = self.neo_reader.get_analogsignal_chunk(block_index=self.block_index, seg_index=self.seg_index,
+                                                                i_start=start_frame, i_stop=end_frame,
+                                                                channel_indexes=None, channel_names=None,
+                                                                stream_index=0, channel_ids=neo_chan_ids)
+        else:
+            raw_traces = self.neo_reader.get_analogsignal_chunk(block_index=self.block_index, seg_index=self.seg_index,
+                                                                i_start=start_frame, i_stop=end_frame,
+                                                                channel_indexes=None, channel_names=None,
+                                                                channel_ids=neo_chan_ids)
         # neo works with (samples, channels) strides
         # so transpose to spikeextractors wolrd
         return raw_traces.transpose()

--- a/spikeextractors/extractors/neoextractors/neobaseextractor.py
+++ b/spikeextractors/extractors/neoextractors/neobaseextractor.py
@@ -90,7 +90,6 @@ class NeoBaseRecordingExtractor(RecordingExtractor, _NeoBaseExtractor):
 
         # Add channels properties
         header_channels = self.neo_reader.header['signal_channels'][slice(None)]
-        channel_ids = self.get_channel_ids()
         self._neo_chan_ids = self.neo_reader.header['signal_channels']['id']
 
         # In neo there is not guarantee that channel ids are unique.
@@ -102,10 +101,10 @@ class NeoBaseRecordingExtractor(RecordingExtractor, _NeoBaseExtractor):
         self._channel_ids = list(np.arange(len(self._neo_chan_ids)))
 
         gains = header_channels['gain'] * self.additional_gain[0]
-        self.set_channel_gains(gains=gains, channel_ids=channel_ids)
+        self.set_channel_gains(gains=gains, channel_ids=self._channel_ids)
 
         names = header_channels['name']
-        for i, ind in enumerate(channel_ids):
+        for i, ind in enumerate(self._channel_ids):
             self.set_channel_property(channel_id=ind, property_name='name', value=names[i])
 
     @check_get_traces_args

--- a/spikeextractors/extractors/neoextractors/neobaseextractor.py
+++ b/spikeextractors/extractors/neoextractors/neobaseextractor.py
@@ -117,6 +117,10 @@ class NeoBaseRecordingExtractor(RecordingExtractor, _NeoBaseExtractor):
 
     def get_channel_ids(self):
         chan_ids = self.neo_reader.header['signal_channels']['id']
+
+        # force chan_ids to be int (new neo default=str)
+        chan_ids = [int(i) for i in chan_ids]
+
         # in neo there is not garranty that chann ids are unique
         # for instance Blacrock can have several times the same chan_id
         # different sampling rate

--- a/spikeextractors/extractors/neoextractors/neobaseextractor.py
+++ b/spikeextractors/extractors/neoextractors/neobaseextractor.py
@@ -98,7 +98,13 @@ class NeoBaseRecordingExtractor(RecordingExtractor, _NeoBaseExtractor):
         # so check it
         assert np.unique(self._neo_chan_ids).size == self._neo_chan_ids.size, 'In this format channel ids are not ' \
                                                                               'unique! Incompatible with SpikeInterface'
-        self._channel_ids = list(np.arange(len(self._neo_chan_ids)))
+
+        try:
+            channel_ids = [int(ch) for ch in self._neo_chan_ids]
+        except Exception as e:
+            warnings.warn("Could not parse channel ids to int: using linear channel map")
+            channel_ids = list(np.arange(len(self._neo_chan_ids)))
+        self._channel_ids = channel_ids
 
         gains = header_channels['gain'] * self.additional_gain[0]
         self.set_channel_gains(gains=gains, channel_ids=self._channel_ids)

--- a/spikeextractors/extractors/neoextractors/neobaseextractor.py
+++ b/spikeextractors/extractors/neoextractors/neobaseextractor.py
@@ -131,7 +131,7 @@ class NeoBaseRecordingExtractor(RecordingExtractor, _NeoBaseExtractor):
         chan_ids = self.neo_reader.header['signal_channels']['id']
 
         # force chan_ids to be int (new neo default=str)
-        chan_ids = [int(i) for i in chan_ids]
+        chan_ids = np.array([np.int(i) for i in chan_ids])
 
         # in neo there is not garranty that chann ids are unique
         # for instance Blacrock can have several times the same chan_id


### PR DESCRIPTION
@alejoe91 
I only changed 1 thing: Forced chan_ids to be np.ndarray of integers. In python-neo it is now by default a np.ndarray of 'U64's, i.e. strings. See here for the changes to python-neo: https://github.com/NeuralEnsemble/python-neo/pull/949

