### PR TITLE
Clear gains and offsets for sub and multi rec extractors 

### DIFF
--- a/spikeextractors/multirecordingchannelextractor.py
+++ b/spikeextractors/multirecordingchannelextractor.py
@@ -15,7 +15,6 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
         self._first_recording = recordings[0]
         self._sampling_frequency = self._first_recording.get_sampling_frequency()
         self._num_frames = self._first_recording.get_num_frames()
-        self.has_unscaled = self._first_recording.has_unscaled
 
         use_times = True
         if np.all([rec._times is not None for rec in self._recordings]):
@@ -72,15 +71,6 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
             locations = np.vstack((locations, recording.get_channel_locations()))
         self.set_channel_locations(locations)
 
-        # set channel gains and offsets
-        gains = np.array([])
-        offsets = np.array([])
-        for i, recording in enumerate(recordings):
-            gains = np.concatenate((gains, recording.get_channel_gains()))
-            offsets = np.concatenate((offsets, recording.get_channel_offsets()))
-        self.set_channel_gains(gains)
-        self.set_channel_offsets(offsets)
-
         #set all normal properties
         for channel_id in self.get_channel_ids():
             recording = self._recordings[self._channel_map[channel_id]['recording']]
@@ -89,6 +79,13 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
                 if property_name not in ("group", "location"):
                     value = recording.get_channel_property(channel_id_recording, property_name)
                     self.set_channel_property(channel_id=channel_id, property_name=property_name, value=value)
+
+        # avoid rescaling twice
+        self.set_channel_gains(1)
+        self.set_channel_offsets(0)
+
+        self.is_filtered = self._first_recording.is_filtered
+        self.has_unscaled = self._first_recording.has_unscaled
 
         self._kwargs = {'recordings': [rec.make_serialized_dict() for rec in recordings], 'groups': groups}
 

--- a/spikeextractors/multirecordingchannelextractor.py
+++ b/spikeextractors/multirecordingchannelextractor.py
@@ -81,8 +81,8 @@ class MultiRecordingChannelExtractor(RecordingExtractor):
                     self.set_channel_property(channel_id=channel_id, property_name=property_name, value=value)
 
         # avoid rescaling twice
-        self.set_channel_gains(1)
-        self.set_channel_offsets(0)
+        self.clear_channel_gains()
+        self.clear_channel_offsets()
 
         self.is_filtered = self._first_recording.is_filtered
         self.has_unscaled = self._first_recording.has_unscaled

--- a/spikeextractors/multirecordingtimeextractor.py
+++ b/spikeextractors/multirecordingtimeextractor.py
@@ -13,7 +13,6 @@ class MultiRecordingTimeExtractor(RecordingExtractor):
         self._num_channels = self._first_recording.get_num_channels()
         self._channel_ids = self._first_recording.get_channel_ids()
         self._sampling_frequency = self._first_recording.get_sampling_frequency()
-        self.has_unscaled = self._first_recording.has_unscaled
 
         if epoch_names is None:
             epoch_names = [str(i) for i in range(len(recordings))]
@@ -54,6 +53,14 @@ class MultiRecordingTimeExtractor(RecordingExtractor):
 
         # Set the channel properties based on the first recording extractor
         self.copy_channel_properties(self._first_recording)
+
+        # avoid rescaling twice
+        self.set_channel_gains(1)
+        self.set_channel_offsets(0)
+
+        self.is_filtered = self._first_recording.is_filtered
+        self.has_unscaled = self._first_recording.has_unscaled
+
         self._kwargs = {'recordings': [rec.make_serialized_dict() for rec in recordings], 'epoch_names': epoch_names}
 
     @property

--- a/spikeextractors/multirecordingtimeextractor.py
+++ b/spikeextractors/multirecordingtimeextractor.py
@@ -55,8 +55,8 @@ class MultiRecordingTimeExtractor(RecordingExtractor):
         self.copy_channel_properties(self._first_recording)
 
         # avoid rescaling twice
-        self.set_channel_gains(1)
-        self.set_channel_offsets(0)
+        self.clear_channel_gains()
+        self.clear_channel_offsets()
 
         self.is_filtered = self._first_recording.is_filtered
         self.has_unscaled = self._first_recording.has_unscaled

--- a/spikeextractors/subrecordingextractor.py
+++ b/spikeextractors/subrecordingextractor.py
@@ -32,8 +32,8 @@ class SubRecordingExtractor(RecordingExtractor):
         self.copy_channel_properties(parent_recording, channel_ids=self._renamed_channel_ids)
 
         # avoid rescaling twice
-        self.set_channel_gains(1)
-        self.set_channel_offsets(0)
+        self.clear_channel_gains()
+        self.clear_channel_offsets()
 
         self.is_filtered = self._parent_recording.is_filtered
         self.has_unscaled = self._parent_recording.has_unscaled

--- a/spikeextractors/subrecordingextractor.py
+++ b/spikeextractors/subrecordingextractor.py
@@ -13,7 +13,7 @@ class SubRecordingExtractor(RecordingExtractor):
         self._renamed_channel_ids = renamed_channel_ids
         self._start_frame = start_frame
         self._end_frame = end_frame
-        self.has_unscaled = self._parent_recording.has_unscaled
+
         if self._channel_ids is None:
             self._channel_ids = self._parent_recording.get_channel_ids()
         if self._renamed_channel_ids is None:
@@ -30,7 +30,13 @@ class SubRecordingExtractor(RecordingExtractor):
             self._original_channel_id_lookup[self._renamed_channel_ids[i]] = self._channel_ids[i]
         RecordingExtractor.__init__(self)
         self.copy_channel_properties(parent_recording, channel_ids=self._renamed_channel_ids)
+
+        # avoid rescaling twice
+        self.set_channel_gains(1)
+        self.set_channel_offsets(0)
+
         self.is_filtered = self._parent_recording.is_filtered
+        self.has_unscaled = self._parent_recording.has_unscaled
 
         # update dump dict
         self._kwargs = {'parent_recording': parent_recording.make_serialized_dict(), 'channel_ids': channel_ids,


### PR DESCRIPTION
This PR fixes a multiple scaling issue when multiple Sub or Multi RecordingExtractors are constructed. 

Originally, all properties are copied to the Sub-Multi extractors, including gains and offsets. Weh retrieving scaled traces, each extractor would apply the scaling, resulting in multiple scaling. 

This PR fixes this behavior by clearing gains and offsets of Sub and Multi extractors.