### PR TITLE
Nwbsortingextractor err msg

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -1113,8 +1113,8 @@ class NwbSortingExtractor(se.SortingExtractor):
                     if len(nwbfile.acquisition) > 1:
                         raise Exception('More than one acquisition found. You must specify electrical_series.')
                     if len(nwbfile.acquisition) == 0:
-                        raise Exception('No acquisitions found in the .nwb file from which to read sampling frequency. \
-                                         Please, specify sampling_frequency parameter.')
+                        raise Exception("No acquisitions found in the .nwb file from which to read sampling frequency. \
+                                         Please, specify 'sampling_frequency' parameter.")
                     es = list(nwbfile.acquisition.values())[0]
                 else:
                     es = electrical_series

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -1113,7 +1113,8 @@ class NwbSortingExtractor(se.SortingExtractor):
                     if len(nwbfile.acquisition) > 1:
                         raise Exception('More than one acquisition found. You must specify electrical_series.')
                     if len(nwbfile.acquisition) == 0:
-                        raise Exception('No acquisitions found in the .nwb file.')
+                        raise Exception('No acquisitions found in the .nwb file from which to read sampling frequency. \
+                                         Please, specify sampling_frequency parameter.')
                     es = list(nwbfile.acquisition.values())[0]
                 else:
                     es = electrical_series


### PR DESCRIPTION
I changed the error message that appears when trying to reading an nwbsortingextractor from an nwb file, when there is no acquisition data in the file from which to read the sampling frequency. The error message is now more informative, informing the user that specifying the `sampling_frequency` paramater will fix the error. 

@alejoe91 I did not change anything in the code, only the error message, so this should be mergable right away. 

Oh, but I already have changes from axonaextractor in here. Should I branch from spikeinterface:master and redo?