### PR TITLE
NwbRecordingExtractor.write_recording extended options

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -736,8 +736,8 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                 ecephys_mod.add(LFP(name='LFP'))
 
         # If user passed metadata info, overwrite defaults
-        if es_key is not None and metadata is not None:
-            assert es_key in metadata.get('Ecephys', dict()).keys(), f"Metadata dictionary does not contain key '{es_key}'"
+        if metadata is not None and 'Ecephys' in metadata and es_key is not None:
+            assert es_key in metadata['Ecephys'], f"metadata['Ecephys'] dictionary does not contain key '{es_key}'"
             eseries_kwargs.update(metadata['Ecephys'][es_key])
 
         # Check for existing names in nwbfile

--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -677,7 +677,10 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             If True, the times are saved to the nwb file using recording.frame_to_time(). If False (defualut),
             the sampling rate is used.
         write_as: str (optional, defaults to 'raw')
-            Options: 'raw', 'lfp' or 'processed'
+            How to save the traces data in the nwb file. Options: 
+            - 'raw' will save it in acquisition
+            - 'processed' will save it as FilteredEphys, in a processing module
+            - 'lfp' will save it as LFP, in a processing module
         es_key: str (optional)
             Key in metadata dictionary containing metadata info for the specific electrical series
         write_scaled: bool (optional, defaults to True)
@@ -902,7 +905,10 @@ class NwbRecordingExtractor(se.RecordingExtractor):
             Check the auxiliary function docstrings for more information
             about metadata format.
         write_as: str (optional, defaults to 'raw')
-            Options: 'raw', 'lfp' or 'processed'
+            How to save the traces data in the nwb file. Options: 
+            - 'raw' will save it in acquisition
+            - 'processed' will save it as FilteredEphys, in a processing module
+            - 'lfp' will save it as LFP, in a processing module
         es_key: str (optional)
             Key in metadata dictionary containing metadata info for the specific electrical series
         write_scaled: bool (optional, defaults to True)
@@ -998,7 +1004,10 @@ class NwbRecordingExtractor(se.RecordingExtractor):
                 metadata['Ecephys']['ElectricalSeries'] = {'name': my_name,
                                                            'description': my_description}
         write_as: str (optional, defaults to 'raw')
-            Options: 'raw', 'lfp' or 'processed'
+            How to save the traces data in the nwb file. Options: 
+            - 'raw' will save it in acquisition
+            - 'processed' will save it as FilteredEphys, in a processing module
+            - 'lfp' will save it as LFP, in a processing module
         es_key: str (optional)
             Key in metadata dictionary containing metadata info for the specific electrical series
         write_scaled: bool (optional, defaults to True)

--- a/spikeextractors/testing.py
+++ b/spikeextractors/testing.py
@@ -1,7 +1,8 @@
 import os
 import shutil
 from pathlib import Path
-
+import uuid
+from datetime import datetime
 import numpy as np
 
 from .extraction_tools import load_extractor_from_pickle, load_extractor_from_dict, \
@@ -178,3 +179,36 @@ def check_dumping(extractor):
         os.remove('spikeinterface_recording.pkl')
     if Path('spikeinterface_sorting.pkl').is_file():
         os.remove('spikeinterface_sorting.pkl')
+
+
+def get_default_nwbfile_metadata():
+    """
+    Returns structure with defaulted metadata values required for a NWBFile.
+    """
+    metadata = dict(
+        NWBFile=dict(
+            session_description="no description",
+            session_start_time=datetime(1970, 1, 1),
+            identifier=str(uuid.uuid4())
+        ),
+        Ecephys=dict(
+            Device=[dict(
+                name='Device_ecephys',
+                description='no description'
+            )],
+            ElectrodeGroup=[],
+            ElectricalSeries_raw=dict(
+                name='raw_traces',
+                description='those are the raw traces'
+            ),
+            ElectricalSeries_processed=dict(
+                name='processed_traces',
+                description='those are the processed traces'
+            ),
+            ElectricalSeries_lfp=dict(
+                name='lfp_traces',
+                description='those are the lfp traces'
+            )
+        )
+    )
+    return metadata

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -8,9 +8,8 @@ import numpy as np
 
 import spikeextractors as se
 from spikeextractors.exceptions import NotDumpableExtractorError
-from spikeextractors.testing import check_sortings_equal, check_recordings_equal, check_dumping, \
-    check_recording_return_types, \
-    check_sorting_return_types
+from spikeextractors.testing import (check_sortings_equal, check_recordings_equal, check_dumping,
+    check_recording_return_types, check_sorting_return_types, get_default_nwbfile_metadata)
 
 
 class TestExtractors(unittest.TestCase):
@@ -547,6 +546,40 @@ class TestExtractors(unittest.TestCase):
         assert 'widths' not in SX_nwb.get_shared_unit_spike_feature_names()
         check_sortings_equal(self.SX2, SX_nwb)
         check_dumping(SX_nwb)
+
+        # Test writting multiple recordings using metadata
+        metadata = get_default_nwbfile_metadata()
+        path_nwb = self.test_dir + '/test_multiple.nwb'
+        se.NwbRecordingExtractor.write_recording(
+            recording=self.RX, 
+            save_path=path_nwb,
+            metadata=metadata,
+            write_as='raw',
+            es_key='ElectricalSeries_raw',
+        )
+        se.NwbRecordingExtractor.write_recording(
+            recording=self.RX2, 
+            save_path=path_nwb,
+            metadata=metadata,
+            write_as='processed',
+            es_key='ElectricalSeries_processed',
+        )
+        se.NwbRecordingExtractor.write_recording(
+            recording=self.RX3, 
+            save_path=path_nwb,
+            metadata=metadata,
+            write_as='lfp',
+            es_key='ElectricalSeries_lfp',
+        )
+
+        RX_nwb = se.NwbRecordingExtractor(
+            file_path=path_nwb,
+            electrical_series_name='raw_traces'
+        )
+        check_recording_return_types(RX_nwb)
+        check_recordings_equal(self.RX, RX_nwb)
+        check_dumping(RX_nwb)
+        del RX_nwb
 
     def test_nixio_extractor(self):
         path1 = os.path.join(self.test_dir, 'raw.nix')


### PR DESCRIPTION
Extend options when writing to nwb. 
See https://github.com/catalystneuro/nwb-conversion-tools/pull/172

Allows `se.NwbRecordingExtractor.write_recording()` to choose between three options for type of electrical series:
- `raw` will save it in acquisition
- `processed` will save it as FilteredEphys
- `lfp` will save it as LFP

If no nwb metadata is passed, default values are used. 
If nwb metadata with many electrical_series keys is passed, the arg `es_key` should indicate which specific metadata key corresponds to the data being written.