### PR TITLE
issue with slicing in mearec

### DIFF
--- a/spikeextractors/extractors/mearecextractors/mearecextractors.py
+++ b/spikeextractors/extractors/mearecextractors/mearecextractors.py
@@ -80,7 +80,7 @@ class MEArecRecordingExtractor(RecordingExtractor):
         if np.any(np.diff(channel_ids) < 0):
             sorted_channel_ids = np.sort(channel_ids)
             sorted_idx = np.array([list(sorted_channel_ids).index(ch) for ch in channel_ids])
-            recordings = self._recordings[start_frame:end_frame, sorted_channel_ids]
+            recordings = self._recordings[start_frame:end_frame, sorted_channel_ids.tolist()]
             return np.array(recordings[:, sorted_idx]).T
         else:
             if sorted(channel_ids) == channel_ids and np.all(np.diff(channel_ids) == 1):


### PR DESCRIPTION
Sorry I have been MIA for a while (working on finishing up my thesis).  I caught this issue when helping someone getting spikeinterface working. Basically, the channel_ids are converted into a numpy array with the sort operation and will cause the slicing to fail. You have to convert it to a list to make it work. Surprisingly, casting it as a list does not work, you have to use numpy.tolist().