### PR TITLE
electrodes table column add problem

### DIFF
--- a/spikeextractors/extractors/nwbextractors/nwbextractors.py
+++ b/spikeextractors/extractors/nwbextractors/nwbextractors.py
@@ -540,7 +540,7 @@ class NwbRecordingExtractor(se.RecordingExtractor):
 
         for metadata_column in metadata['Ecephys']['Electrodes']:
             if (nwbfile.electrodes is None or metadata_column['name'] not in nwbfile.electrodes.colnames) \
-                    and metadata_column['name'] != 'group_name':
+                    and metadata_column['name'] not in defaults:
                 nwbfile.add_electrode_column(
                     name=str(metadata_column['name']),
                     description=str(metadata_column['description'])


### PR DESCRIPTION
I'm trying to add a custom data to existing default columns in the Electrodes table of nwb and not trying to add any new column to this table. 
The metadata is like:
```python
metadata['Ecephys']['Electrodes'] = [dict(name='filtering',
                                                  description='filtering',
                                                  data=['1000Hz']*96),
                                             dict(name='group_name',
                                                  description='electrode group name',
                                                  data=self._group_name*96)
                                             ]
```
`filtering `and `group_name `are default colnames for this table, the values of which I want to override. However, the `write_electrodes()` method ends up calling `nwbfile.add_electrode_column()` for these and thus throws an error. 


This PR is for the fix that prevents this problem. 