### PR TITLE
numpy channel ids setting

### DIFF
--- a/spikeextractors/extractors/numpyextractors/numpyextractors.py
+++ b/spikeextractors/extractors/numpyextractors/numpyextractors.py
@@ -41,6 +41,7 @@ class NumpyRecordingExtractor(RecordingExtractor):
 
         self._ttl_frames = None
         self._ttl_states = None
+        self._channel_ids = list(range(self._timeseries.shape[0]))
 
     def set_ttls(self, ttl_frames, ttl_states=None):
         self._ttl_frames = ttl_frames.astype('int64')
@@ -50,7 +51,7 @@ class NumpyRecordingExtractor(RecordingExtractor):
             self._ttl_states = np.ones_like(ttl_frames, dtype='int64')
 
     def get_channel_ids(self):
-        return list(range(self._timeseries.shape[0]))
+        return self._channel_ids
 
     def get_num_frames(self):
         return self._timeseries.shape[1]


### PR DESCRIPTION
functionality to manually set channel ids to a `NumpyRecordingExtractor`. I'm proposing that we use an internal attribute `self._channel_ids` that the get method returns. This way for the 1% case when the channel ids need to be changed, the internal attribute can be overridden. Its similar to what the `NeoBaseRecordingExtractor` is using. 
For a broader applicability, we could have a `set_channel_ids`() method in the `RecordingExtractor` base class. Again, this may be useful only in a minority of cases, but just an extra method and few lines of code in the base class would suffice without breaking anything downstream. What do you all think?