### PR TITLE
return CED data as np.array instead of python list

### DIFF
--- a/spikeextractors/extractors/cedextractors/utils.py
+++ b/spikeextractors/extractors/cedextractors/utils.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 try:
     from sonpy import lib as sp
 
@@ -87,4 +89,4 @@ def get_channel_data(f, smrx_ch_ind, start_frame=0, end_frame=None):
         tUpto=int(end_frame * f.ChannelDivide(smrx_ch_ind))
     )
 
-    return data
+    return np.array(data)


### PR DESCRIPTION
- reduces RAM usage of [get_traces](https://github.com/SpikeInterface/spikeextractors/blob/118aa9d2acb395e76bcb40c80a9db6f28a054230/spikeextractors/extractors/cedextractors/cedrecordingextractor.py#L101) (21GB -> 13GB for a small test smrx file with 32 channels)
- could be further reduced by using a smaller np data type (which it looks like [neo already does](https://github.com/samuelgarcia/python-neo/blob/master/neo/rawio/cedrawio.py#L82))
