### PR TITLE
NwbRecording extractor get_traces() with scrambled ids

### DIFF
--- a/full_requirements.txt
+++ b/full_requirements.txt
@@ -6,7 +6,7 @@ neo>=0.9.0
 MEArec>=1.7.2
 pynwb>=1.4
 lxml>=4.6.3
-nixio>=1.5.0
+nixio==1.5.0
 shybrid>=0.4.2
 pyyaml>=5.4.1
 mtscomp>=1.0.1


### PR DESCRIPTION
One of the things we were aware of from PR #600 and issue #587 that may have gotten a bit lost in the monster changelog that was PR #571, was how the NwbRecordingExtractor has to deal with the constraint that h5 datasets must have their data accessed by slices in sorted (strictly increasing) order.

This came up as I was building GIN tests for the SpikeGadgets format on nwb-conversion-tools, since both instances of that data on GIN have scrambled channel_id order. Note that SpikeGadgets did not make it into this the GIN testing for this version of spikeextractors, hence why this has never cropped up so formally before.

Anyway, this fixes the issue for me, as seen [here](https://github.com/catalystneuro/nwb-conversion-tools/pull/246) Also should be more efficient with the new `argsort` usage.