### PR TITLE
remove .cbin support

### DIFF
--- a/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
+++ b/spikeextractors/extractors/spikeglxrecordingextractor/spikeglxrecordingextractor.py
@@ -60,15 +60,7 @@ class SpikeGLXRecordingExtractor(RecordingExtractor):
         self._meta = meta
 
         # Traces in 16-bit format
-        if '.cbin' in self._npxfile.name: # compressed binary format used by IBL
-            try:
-                import mtscomp
-            except:
-                raise Exception(self.installation_mesg)
-            self._raw = mtscomp.Reader()
-            self._raw.open(self._npxfile, self._npxfile.with_suffix('.ch'))
-        else:
-            self._raw = makeMemMapRaw(self._npxfile, meta)  # [chanList, firstSamp:lastSamp+1]
+        self._raw = makeMemMapRaw(self._npxfile, meta)  # [chanList, firstSamp:lastSamp+1]
 
         # sampling rate and ap channels
         self._sampling_frequency = SampRate(meta)


### PR DESCRIPTION
compressed .bin files (used mainly by IBL) is stored as shape (samples, channels) while `SpikeGLXRecordingExtractor` expects the transpose of this. 

Currently opening the .cbin format using mtscomp cannot be transposed initially since its compressed and not stored as a np.memmap. So to actually support .cbin we would have to add if loops to transpose what ever is retrieved. It would be better to create a new class like `SpikeGLXCompressedRecordingExtractor` or something or drop the support altogether (new spikeinterface any does not support this as neo does not). 

When I tried opening a .cbin file, the method ended up chopping the time dimension instead of the channels

@samuelgarcia @alejoe91 what do you guys think? : letting go of being able to open .cbin files or creating a new class?