### PR TITLE
Adding matlab reading capabilities for new format in CellExplorerExtractor

### DIFF
--- a/spikeextractors/extractors/cellexplorersortingextractor/cellexplorersortingextractor.py
+++ b/spikeextractors/extractors/cellexplorersortingextractor/cellexplorersortingextractor.py
@@ -42,9 +42,10 @@ class CellExplorerSortingExtractor(SortingExtractor):
         assert (
             spikes_matfile_path.is_file()
         ), f"The spikes_matfile_path ({spikes_matfile_path}) must exist!"
-        folder_path = spikes_matfile_path.parent
-        sorting_id = spikes_matfile_path.name.split(".")[0]
+        
         if sampling_frequency is None:
+            folder_path = spikes_matfile_path.parent
+            sorting_id = spikes_matfile_path.name.split(".")[0]
             if session_info_matfile_path is None:
                 session_info_matfile_path = folder_path / f"{sorting_id}.sessionInfo.mat"
 
@@ -55,14 +56,13 @@ class CellExplorerSortingExtractor(SortingExtractor):
             try:
                 session_info_mat = scipy.io.loadmat(file_name=str(session_info_matfile_path))
                 self.read_session_info_with_scipy = True
-            except:  # <- Find out exactly what error does this produce - don't use bare excepts
+            except NotImplementedError:
                 session_info_mat = hdf5storage.loadmat(file_name=str(session_info_matfile_path))
                 self.read_session_info_with_scipy = False
-           
-           # Check the assert and extraction logic depending on read_session_info_with
+            
             assert session_info_mat["sessionInfo"]["rates"][0][0]["wideband"], (
                 "The sesssionInfo.mat file must contain "
-                "a 'sessionInfo' struct with field 'rates' containing field 'wideband'!"
+                "a 'sessionInfo' struct with field 'rates' containing field 'wideband' to extract the sampling frequency!"
             )
             if self.read_session_info_with_scipy:
                 self._sampling_frequency = float(
@@ -79,7 +79,7 @@ class CellExplorerSortingExtractor(SortingExtractor):
         try:
             spikes_mat = scipy.io.loadmat(file_name=str(spikes_matfile_path))
             self.read_spikes_info_with_scipy = True
-        except:  # <- Find out exactly what error does this produce - don't use bare excepts
+        except NotImplementedError: 
             spikes_mat = hdf5storage.loadmat(file_name=str(spikes_matfile_path))
             self.read_spikes_info_with_scipy = False
 

--- a/spikeextractors/extractors/cellexplorersortingextractor/cellexplorersortingextractor.py
+++ b/spikeextractors/extractors/cellexplorersortingextractor/cellexplorersortingextractor.py
@@ -70,7 +70,7 @@ class CellExplorerSortingExtractor(SortingExtractor):
                 )  # careful not to confuse it with the lfpsamplingrate; reported in units Hz
             else:
                 self._sampling_frequency = float(
-                    session_info_mat["sessionInfo"]["rates"][0][0]["wideband"][0][0][0][0]
+                    session_info_mat["sessionInfo"]["rates"][0][0]["wideband"][0][0]
                 )  # careful not to confuse it with the lfpsamplingrate; reported in units Hz
         else:
             self._sampling_frequency = sampling_frequency

--- a/spikeextractors/extractors/cellexplorersortingextractor/cellexplorersortingextractor.py
+++ b/spikeextractors/extractors/cellexplorersortingextractor/cellexplorersortingextractor.py
@@ -50,7 +50,7 @@ class CellExplorerSortingExtractor(SortingExtractor):
 
             assert (
                 session_info_matfile_path.is_file()
-            ), "No sessionInfo.mat file found in the folder!" 
+            ), f"No {sorting_id}.sessionInfo.mat file found in the folder!" 
 
             try:
                 session_info_mat = scipy.io.loadmat(file_name=str(session_info_matfile_path))
@@ -73,6 +73,7 @@ class CellExplorerSortingExtractor(SortingExtractor):
                     session_info_mat["sessionInfo"]["rates"][0][0]["wideband"][0][0]
                 )  # careful not to confuse it with the lfpsamplingrate; reported in units Hz
         else:
+            assert sampling_frequency is not None, "Could not load sampling frequency from files. Use the 'sampling_frequency' argument"
             self._sampling_frequency = sampling_frequency
 
         try:

--- a/spikeextractors/extractors/cellexplorersortingextractor/cellexplorersortingextractor.py
+++ b/spikeextractors/extractors/cellexplorersortingextractor/cellexplorersortingextractor.py
@@ -73,7 +73,6 @@ class CellExplorerSortingExtractor(SortingExtractor):
                     session_info_mat["sessionInfo"]["rates"][0][0]["wideband"][0][0]
                 )  # careful not to confuse it with the lfpsamplingrate; reported in units Hz
         else:
-            assert sampling_frequency is not None, "Could not load sampling frequency from files. Use the 'sampling_frequency' argument"
             self._sampling_frequency = sampling_frequency
 
         try:

--- a/spikeextractors/extractors/cellexplorersortingextractor/cellexplorersortingextractor.py
+++ b/spikeextractors/extractors/cellexplorersortingextractor/cellexplorersortingextractor.py
@@ -2,15 +2,18 @@ from spikeextractors import SortingExtractor
 import numpy as np
 from pathlib import Path
 from spikeextractors.extraction_tools import check_get_unit_spike_train
-from typing import Union
+from typing import Union, Optional
 
 try:
-    from scipy.io import loadmat, savemat
-    HAVE_SCIPY = True
+    import scipy.io 
+    import hdf5storage
+    HAVE_SCIPY_AND_HDF5STORAGE = True
 except ImportError:
-    HAVE_SCIPY = False
+    HAVE_SCIPY_AND_HDF5STORAGE = False
+
 
 PathType = Union[str, Path]
+OptionalPathType = Optional[PathType]  
 
 
 class CellExplorerSortingExtractor(SortingExtractor):
@@ -26,40 +29,66 @@ class CellExplorerSortingExtractor(SortingExtractor):
     """
 
     extractor_name = "CellExplorerSortingExtractor"
-    installed = HAVE_SCIPY
+    installed = HAVE_SCIPY_AND_HDF5STORAGE
     is_writable = True
     mode = "file"
-    installation_mesg = "To use the CellExplorerSortingExtractor install scipy: \n\n pip install scipy\n\n"
+    installation_mesg = "To use the CellExplorerSortingExtractor install scipy and hdf5storage: \n\n pip install scipy\n\n and  \n\n pip install hdf5 storage \n\n"
 
-    def __init__(self, spikes_matfile_path: PathType):
+    def __init__(self, spikes_matfile_path: PathType, session_info_matfile_path: OptionalPathType=None, sampling_frequency: Optional[float] = None):
         assert self.installed, self.installation_mesg
         SortingExtractor.__init__(self)
 
         spikes_matfile_path = Path(spikes_matfile_path)
-        assert spikes_matfile_path.is_file(), f"The spikes_matfile_path ({spikes_matfile_path}) must exist!"
+        assert (
+            spikes_matfile_path.is_file()
+        ), f"The spikes_matfile_path ({spikes_matfile_path}) must exist!"
         folder_path = spikes_matfile_path.parent
         sorting_id = spikes_matfile_path.name.split(".")[0]
+        if sampling_frequency is None:
+            if session_info_matfile_path is None:
+                session_info_matfile_path = folder_path / f"{sorting_id}.sessionInfo.mat"
 
-        session_info_matfile_path = folder_path / f"{sorting_id}.sessionInfo.mat"
-        assert session_info_matfile_path.is_file(), "No sessionInfo.mat file found in the folder!"
-        session_info_mat = loadmat(file_name=str(session_info_matfile_path.absolute()))
-        assert session_info_mat['sessionInfo']['rates'][0][0]['wideband'], "The sesssionInfo.mat file must contain " \
-            "a 'sessionInfo' struct with field 'rates' containing field 'wideband'!"
-        self._sampling_frequency = float(
-            session_info_mat['sessionInfo']['rates'][0][0]['wideband'][0][0][0][0]
-        )  # careful not to confuse it with the lfpsamplingrate; reported in units Hz
+            assert (
+                session_info_matfile_path.is_file()
+            ), "No sessionInfo.mat file found in the folder!" 
 
-        spikes_mat = loadmat(file_name=str(spikes_matfile_path.absolute()))
-        assert np.all(np.isin(['UID', 'times'], spikes_mat['spikes'].dtype.names)), \
-            "The spikes.cellinfo.mat file must contain a 'spikes' struct with fields 'UID' and 'times'!"
+            try:
+                session_info_mat = scipy.io.loadmat(file_name=str(session_info_matfile_path))
+                read_session_info_with = 'scipy'
+            except:  # <- Find out exactly what error does this produce - don't use bare excepts
+                session_info_mat = hdf5storage.loadmat(file_name=str(session_info_matfile_path))
+                read_session_info_with = 'hdf5storage'
+           
+           # Check the assert and extraction logic depending on read_session_info_with
+            assert session_info_mat["sessionInfo"]["rates"][0][0]["wideband"], (
+                "The sesssionInfo.mat file must contain "
+                "a 'sessionInfo' struct with field 'rates' containing field 'wideband'!"
+            )
+            self._sampling_frequency = float(
+                session_info_mat["sessionInfo"]["rates"][0][0]["wideband"][0][0][0][0]
+            )  # careful not to confuse it with the lfpsamplingrate; reported in units Hz
+        
+        else:
+            self._sampling_frequency = sampling_frequency
 
-        self._unit_ids = np.asarray(spikes_mat['spikes']['UID'][0][0][0], dtype=int)
+        try:
+            spikes_mat = scipy.io.loadmat(file_name=str(session_info_matfile_path))
+            read_spikes_info_with = 'scipy'
+        except:  # <- Find out exactly what error does this produce - don't use bare excepts
+            spikes_mat = hdf5storage.loadmat(file_name=str(session_info_matfile_path))
+            read_spkies_info_with = 'hdf5storage'
+
+        assert np.all(
+            np.isin(["UID", "times"], spikes_mat["spikes"].dtype.names)
+        ), "The spikes.cellinfo.mat file must contain a 'spikes' struct with fields 'UID' and 'times'!"
+
+        self._unit_ids = np.asarray(spikes_mat["spikes"]["UID"][0][0][0], dtype=int)
         # CellExplorer reports spike times in units seconds; SpikeExtractors uses time units of sampling frames
         # Rounding is necessary to prevent data loss from int-casting floating point errors
         self._spiketrains = [
             (np.array([y[0] for y in x]) * self._sampling_frequency).round().astype(int)
-            for x in spikes_mat['spikes']['times'][0][0][0]
-         ]
+            for x in spikes_mat["spikes"]["times"][0][0][0]
+        ]
 
         self._kwargs = dict(spikes_matfile_path=str(spikes_matfile_path.absolute()))
 
@@ -74,8 +103,11 @@ class CellExplorerSortingExtractor(SortingExtractor):
 
     @staticmethod
     def write_sorting(sorting: SortingExtractor, save_path: PathType):
-        assert save_path.suffixes == ['.spikes', '.cellinfo', '.mat'], \
-            "The save_path must correspond to the CellExplorer format of sorting_id.spikes.cellinfo.mat!"
+        assert save_path.suffixes == [
+            ".spikes",
+            ".cellinfo",
+            ".mat",
+        ], "The save_path must correspond to the CellExplorer format of sorting_id.spikes.cellinfo.mat!"
 
         base_path = save_path.parent
         sorting_id = save_path.name.split(".")[0]
@@ -85,18 +117,17 @@ class CellExplorerSortingExtractor(SortingExtractor):
 
         sampling_frequency = sorting.get_sampling_frequency()
         session_info_mat_dict = dict(
-            sessionInfo=dict(
-                rates=dict(
-                    wideband=sampling_frequency
-                )
-            )
+            sessionInfo=dict(rates=dict(wideband=sampling_frequency))
         )
         savemat(file_name=session_info_save_path, mdict=session_info_mat_dict)
 
         spikes_mat_dict = dict(
             spikes=dict(
                 UID=sorting.get_unit_ids(),
-                times=[[[y / sampling_frequency] for y in x] for x in sorting.get_units_spike_train()]
+                times=[
+                    [[y / sampling_frequency] for y in x]
+                    for x in sorting.get_units_spike_train()
+                ],
             )
         )
         # If, in the future, it is ever desired to allow this to write unit properties, they must conform

--- a/spikeextractors/extractors/cellexplorersortingextractor/cellexplorersortingextractor.py
+++ b/spikeextractors/extractors/cellexplorersortingextractor/cellexplorersortingextractor.py
@@ -76,10 +76,10 @@ class CellExplorerSortingExtractor(SortingExtractor):
             self._sampling_frequency = sampling_frequency
 
         try:
-            spikes_mat = scipy.io.loadmat(file_name=str(session_info_matfile_path))
+            spikes_mat = scipy.io.loadmat(file_name=str(spikes_matfile_path))
             self.read_spikes_info_with_scipy = True
         except:  # <- Find out exactly what error does this produce - don't use bare excepts
-            spikes_mat = hdf5storage.loadmat(file_name=str(session_info_matfile_path))
+            spikes_mat = hdf5storage.loadmat(file_name=str(spikes_matfile_path))
             self.read_spikes_info_with_scipy = False
 
         assert np.all(


### PR DESCRIPTION
The purpose of this pull request is to fix/update some reading problems with the reading of matlab files in the `CellExplorerExtractor` 

1) We add capabilities to consistently read `sessionInfo` and and `spikes.Info` files independently on the matlab format (that is either `scipy.io` or `hdf5storage`).
2) Add the location of the the matlab files as an optional parameter in the extractor.
3) Add the sampling frequency as an optional parameter so a reading of `SessionInfo` is not required.

