### PR TITLE
Avoid installing tridesclous for tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 datalad
 parameterized
-tridesclous
 neo==0.10


### PR DESCRIPTION
Avoid hdbscan installation issues for TDC (GIN tests are skipped and roundtrip test is not relevant anymore)